### PR TITLE
Country selector component integrated with country performance graphs

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "plotly.js": "^1.8.0",
     "react": "^15.4.2",
     "react-dom": "^15.4.2",
+    "react-redux": "^5.0.2",
     "react-select": "^1.0.0-rc.3",
     "redux": "^3.6.0"
   },

--- a/package.json
+++ b/package.json
@@ -5,19 +5,20 @@
   "devDependencies": {
     "chai": "^3.5.0",
     "enzyme": "^2.7.0",
+    "enzyme-to-json": "^1.4.5",
     "jsdom": "^9.9.1",
     "nock": "^9.0.2",
     "react-addons-test-utils": "^15.4.2",
     "react-scripts": "0.8.5",
     "redux-mock-store": "^1.2.2",
-    "redux-thunk": "^2.2.0",
-    "sinon": "^1.17.7"
+    "redux-thunk": "^2.2.0"
   },
   "dependencies": {
     "axios": "^0.15.3",
     "plotly.js": "^1.8.0",
     "react": "^15.4.2",
     "react-dom": "^15.4.2",
+    "react-select": "^1.0.0-rc.3",
     "redux": "^3.6.0"
   },
   "scripts": {

--- a/src/components/CountryPerformanceOnRisk.js
+++ b/src/components/CountryPerformanceOnRisk.js
@@ -23,37 +23,55 @@ export class CountryPerformanceOnRisk extends Component {
   }
 
 
-  computeState() {
+  computeState(props=this.props) {
 
     let state = {
-      data: this.props.data,
-      graphOptions: this.props.graphOptions,
-      countries: this.props.countries,
-      defaultCountry: this.props.defaultCountry,
+      data: props.data,
+      graphOptions: props.graphOptions,
+      countries: props.countries,
+      defaultCountry: props.defaultCountry,
     }
     return state
   }
 
 
   componentDidMount() {
-    this.setState(this.computeState())
+    this.setState(this.computeState(this.props))
   };
 
+  componentWillReceiveProps(nextProps) {
+    this.setState(this.computeState(nextProps))
+  }
 
   updateValue1(newCountry) {
-
+    if (newCountry) {
+      this.props.dispatch({type: "addRemoveLine", id: newCountry.value + '1', idx: 2})
+    } else {
+      this.props.dispatch({type: "addRemoveLine", id: newCountry, idx: 2})
+    }
     this.setState({
       selected1: newCountry
+
     })
   }
 
   updateValue2(newCountry) {
+    if (newCountry) {
+      this.props.dispatch({type: "addRemoveLine", id: newCountry.value + '1', idx: 3})
+    } else {
+      this.props.dispatch({type: "addRemoveLine", id: newCountry, idx: 3})
+    }
     this.setState({
       selected2: newCountry
     })
   }
 
   updateValue3(newCountry) {
+    if (newCountry) {
+      this.props.dispatch({type: "addRemoveLine", id: newCountry.value + '1', idx: 4})
+    } else {
+      this.props.dispatch({type: "addRemoveLine", id: newCountry, idx: 4})
+    }
     this.setState({
       selected3: newCountry
     })
@@ -123,7 +141,9 @@ export class CountrySelect extends Component {
 
 const mapStateToProps = (state) => {
   return {
-    data : state.entities.data,
+    data: state.entities.data.filter(data => {
+      return state.graphs[1].dataToshow.indexOf(data.id) !== -1
+    }),
     graphOptions: state.entities.layouts,
     countries: state.entities.countries,
     defaultCountry: state.defaultCountry

--- a/src/components/CountryPerformanceOnRisk.js
+++ b/src/components/CountryPerformanceOnRisk.js
@@ -90,23 +90,23 @@ export class CountryPerformanceOnRisk extends Component {
           disabled={true}
         />
         < CountrySelect
-          selectOptions={[{value: 't', label: 'Total'}]}
+          selectOptions={[{value: 't', label: 'Global'}]}
           disabled={true}
         />
         < CountrySelect
           selectOptions={this.state.countries}
           onChange={this.updateValue1}
-          selectedCountries={this.state.selected1}
+          selectedCountry={this.state.selected1}
         />
         < CountrySelect
           selectOptions={this.state.countries}
           onChange={this.updateValue2}
-          selectedCountries={this.state.selected2}
+          selectedCountry={this.state.selected2}
         />
         < CountrySelect
           selectOptions={this.state.countries}
           onChange={this.updateValue3}
-          selectedCountries={this.state.selected3}
+          selectedCountry={this.state.selected3}
         />
       </div>
     );
@@ -122,14 +122,14 @@ export class CountrySelect extends Component {
   render() {
     let options = this.props.selectOptions
     let update = this.props.onChange
-    let selectedCountries = this.props.selectedCountries
+    let selectedCountry = this.props.selectedCountry
     let disabled = this.props.disabled
     const style = { width: "20%", display: "inline", float: "left" }
     return (
       <div style={style}>
         <Select
           name="countries"
-          value={selectedCountries || options[0]}
+          value={selectedCountry || options[0]}
           options={options}
           onChange={update}
           disabled={disabled}

--- a/src/components/CountryPerformanceOnRisk.js
+++ b/src/components/CountryPerformanceOnRisk.js
@@ -19,33 +19,32 @@ class CountryPerformanceOnRisk extends Component {
   computeState() {
     let xValues = ['2017-01-01','2017-01-08','2017-01-15'];
     let reduxStore = {
+      graphs: {
+        1: {
+          title: 'DDOS-graph',
+          dataToshow: ['t1','t2'],
+          graphLayout: ['l1']
+        }
+      },
       entities: {
-        graphs: {
-            1: {
-            title: 'DDOS-graph',
-            dataToshow: ['t1','t2'],
-            graphLayout: ['l1']
-          }
-         },
-        data: {
-          t1: {
+        data: [
+          {
             x: xValues,
             y: [2,4,6],
             name: 'example N1',
             type: 'scatter'
           },
-          t2: {
+          {
             x: xValues,
             y: [1,4,7],
             name: 'example N2',
             type: 'scatter'
           }
-        },
+        ],
         layouts: {
           l1: {
             title : 'Global DDOS potential',
             height: 600,
-            barmode: 'stack',
             xaxis: {
               title: '*This chart assumes an average 1 mbit/sec Internet connection for every IP address.',
               gridcolor: 'transparent',
@@ -59,13 +58,10 @@ class CountryPerformanceOnRisk extends Component {
           {id: 'uk', name: 'United Kingdom'},
           {id: 'us', name: 'United States'}
         ]
-      },
-      graphsToShow: [1]
+      }
     }
 
     let state = {
-      graphsToShow: reduxStore.graphsToShow,
-      graphs: reduxStore.entities.graphs,
       data : reduxStore.entities.data,
       graphOptions: reduxStore.entities.layouts,
       countries: reduxStore.entities.countries,
@@ -93,31 +89,16 @@ class CountryPerformanceOnRisk extends Component {
 
 
   render() {
-    let graphsToShow = this.state.graphsToShow
-    let graphs = this.state.graphs
-    let data = this.state.data
     let graphOptions = this.state.graphOptions
     return (
       <div>
-        {graphsToShow.map(id => {
-          let dataForGraph = graphs[id].dataToshow.map(line => {
-            return data[line]
-          })
-          let layoutForGraph = graphs[id].graphLayout.map(layout => {
-            return graphOptions[layout]
-          })
-          return <div key={graphs[id].title}>
-            < PlotlyGraph
-            data={dataForGraph}
-            graphOptions={layoutForGraph}
-            graphID={graphs[id].title}/>
-
-            < input type="text"
-              placeholder="Search.."
-              value={this.state.search}
-              onChange={this.handleSearch.bind(this)} />
-          </div>
-        })}
+        <PlotlyGraph
+          data={this.state.data}
+          graphOptions={this.state.graphOptions}
+          graphID='DDOS-graph' />
+        <input type="text"
+          placeholder="Search.."
+          onChange={this.handleSearch.bind(this)} />
       </div>
     );
   }

--- a/src/components/CountryPerformanceOnRisk.js
+++ b/src/components/CountryPerformanceOnRisk.js
@@ -1,17 +1,16 @@
 import React, { Component } from 'react';
-import PlotlyGraph from './Plot.js'
+import PlotlyGraph from './Plot.js';
+import Select from 'react-select';
+import 'react-select/dist/react-select.css';
 
-
-class CountryPerformanceOnRisk extends Component {
+export class CountryPerformanceOnRisk extends Component {
   constructor(props) {
     super(props)
     this.state = {
       data: [],
       graphOptions: {},
       countries: [],
-      matchedCountry: {},
-      graphsToShow: [],
-      graphs: {}
+      defaultCountry: {}
     }
   }
 
@@ -55,31 +54,21 @@ class CountryPerformanceOnRisk extends Component {
           }
         },
         countries: [
-          {id: 'uk', name: 'United Kingdom'},
-          {id: 'us', name: 'United States'}
+          {value: 'uk', label: 'United Kingdom' },
+          {value: 'us', label: 'United States' },
+          {value: 'ge', label: 'Georgia' },
         ]
-      }
+      },
+      defaultCountry: {value: 'uk', label: 'United Kingdom' }
     }
 
     let state = {
       data : reduxStore.entities.data,
       graphOptions: reduxStore.entities.layouts,
       countries: reduxStore.entities.countries,
-      matchedCountry: {}
+      defaultCountry: reduxStore.defaultCountry
     }
     return state
-  }
-
-
-  handleSearch(event) {
-    let searchedCountry = this.state.countries.filter( country => {
-      return country.name.toLowerCase().indexOf(event.target.value.toLowerCase()) !== -1;
-    })
-    if(searchedCountry) {
-      this.setState({
-        matchedCountry: searchedCountry
-      })
-    }
   }
 
 
@@ -89,19 +78,40 @@ class CountryPerformanceOnRisk extends Component {
 
 
   render() {
-    let graphOptions = this.state.graphOptions
     return (
       <div>
         <PlotlyGraph
           data={this.state.data}
           graphOptions={this.state.graphOptions}
           graphID='DDOS-graph' />
-        <input type="text"
-          placeholder="Search.."
-          onChange={this.handleSearch.bind(this)} />
+        < CountrySelect selectOptions={[this.state.defaultCountry]} />
+        < CountrySelect selectOptions={[{value: 't', label: 'Total'}]} />
+        < CountrySelect selectOptions={this.state.countries}/>
+        < CountrySelect selectOptions={this.state.countries}/>
+        < CountrySelect selectOptions={this.state.countries}/>
       </div>
     );
   }
 }
 
-export default CountryPerformanceOnRisk;
+
+export class CountrySelect extends Component {
+  constructor(props) {
+    super(props)
+  }
+
+  render() {
+    let options = this.props.selectOptions
+    const style = { width: "20%", display: "inline", float: "left" }
+    return (
+      <div style={style}>
+        <Select
+          name="countries"
+          options={options}
+        />
+      </div>
+    );
+  }
+}
+
+// export default CountryPerformanceOnRisk;

--- a/src/components/CountryPerformanceOnRisk.js
+++ b/src/components/CountryPerformanceOnRisk.js
@@ -1,7 +1,9 @@
 import React, { Component } from 'react';
+import { connect } from 'react-redux'
 import PlotlyGraph from './Plot.js';
 import Select from 'react-select';
 import 'react-select/dist/react-select.css';
+
 
 export class CountryPerformanceOnRisk extends Component {
   constructor(props) {
@@ -22,58 +24,12 @@ export class CountryPerformanceOnRisk extends Component {
 
 
   computeState() {
-    let xValues = ['2017-01-01','2017-01-08','2017-01-15'];
-    let reduxStore = {
-      graphs: {
-        1: {
-          title: 'DDOS-graph',
-          dataToshow: ['t1','t2'],
-          graphLayout: ['l1']
-        }
-      },
-      entities: {
-        data: [
-          {
-            x: xValues,
-            y: [2,4,6],
-            name: 'example N1',
-            type: 'scatter'
-          },
-          {
-            x: xValues,
-            y: [1,4,7],
-            name: 'example N2',
-            type: 'scatter'
-          }
-        ],
-        layouts: {
-          l1: {
-            title : 'Global DDOS potential',
-            height: 600,
-            xaxis: {
-              title: '*This chart assumes an average 1 mbit/sec Internet connection for every IP address.',
-              gridcolor: 'transparent',
-            },
-            yaxis: {
-              title: 'GBit/sec'
-            }
-          }
-        },
-        countries: [
-          {value: '', label: 'Select a country'},
-          {value: 'uk', label: 'United Kingdom' },
-          {value: 'us', label: 'United States' },
-          {value: 'ge', label: 'Georgia' },
-        ]
-      },
-      defaultCountry: {value: 'uk', label: 'United Kingdom' }
-    }
 
     let state = {
-      data : reduxStore.entities.data,
-      graphOptions: reduxStore.entities.layouts,
-      countries: reduxStore.entities.countries,
-      defaultCountry: reduxStore.defaultCountry
+      data: this.props.data,
+      graphOptions: this.props.graphOptions,
+      countries: this.props.countries,
+      defaultCountry: this.props.defaultCountry,
     }
     return state
   }
@@ -165,4 +121,13 @@ export class CountrySelect extends Component {
   }
 }
 
-export default CountryPerformanceOnRisk;
+const mapStateToProps = (state) => {
+  return {
+    data : state.entities.data,
+    graphOptions: state.entities.layouts,
+    countries: state.entities.countries,
+    defaultCountry: state.defaultCountry
+  }
+}
+
+export default connect(mapStateToProps)(CountryPerformanceOnRisk)

--- a/src/components/CountryPerformanceOnRisk.js
+++ b/src/components/CountryPerformanceOnRisk.js
@@ -95,17 +95,17 @@ export class CountryPerformanceOnRisk extends Component {
         />
         < CountrySelect
           selectOptions={this.state.countries}
-          onchange={this.updateValue1}
+          onChange={this.updateValue1}
           selectedCountries={this.state.selected1}
         />
         < CountrySelect
           selectOptions={this.state.countries}
-          onchange={this.updateValue2}
+          onChange={this.updateValue2}
           selectedCountries={this.state.selected2}
         />
         < CountrySelect
           selectOptions={this.state.countries}
-          onchange={this.updateValue3}
+          onChange={this.updateValue3}
           selectedCountries={this.state.selected3}
         />
       </div>
@@ -121,7 +121,7 @@ export class CountrySelect extends Component {
 
   render() {
     let options = this.props.selectOptions
-    let update = this.props.onchange
+    let update = this.props.onChange
     let selectedCountries = this.props.selectedCountries
     let disabled = this.props.disabled
     const style = { width: "20%", display: "inline", float: "left" }

--- a/src/components/CountryPerformanceOnRisk.js
+++ b/src/components/CountryPerformanceOnRisk.js
@@ -10,8 +10,14 @@ export class CountryPerformanceOnRisk extends Component {
       data: [],
       graphOptions: {},
       countries: [],
-      defaultCountry: {}
+      defaultCountry: {},
+      selected1: undefined,
+      selected2: undefined,
+      selected3: undefined
     }
+    this.updateValue1 = this.updateValue1.bind(this)
+    this.updateValue2 = this.updateValue2.bind(this)
+    this.updateValue3 = this.updateValue3.bind(this)
   }
 
 
@@ -54,6 +60,7 @@ export class CountryPerformanceOnRisk extends Component {
           }
         },
         countries: [
+          {value: '', label: 'Select a country'},
           {value: 'uk', label: 'United Kingdom' },
           {value: 'us', label: 'United States' },
           {value: 'ge', label: 'Georgia' },
@@ -77,6 +84,26 @@ export class CountryPerformanceOnRisk extends Component {
   };
 
 
+  updateValue1(newCountry) {
+
+    this.setState({
+      selected1: newCountry
+    })
+  }
+
+  updateValue2(newCountry) {
+    this.setState({
+      selected2: newCountry
+    })
+  }
+
+  updateValue3(newCountry) {
+    this.setState({
+      selected3: newCountry
+    })
+  }
+
+
   render() {
     return (
       <div>
@@ -84,11 +111,29 @@ export class CountryPerformanceOnRisk extends Component {
           data={this.state.data}
           graphOptions={this.state.graphOptions}
           graphID='DDOS-graph' />
-        < CountrySelect selectOptions={[this.state.defaultCountry]} />
-        < CountrySelect selectOptions={[{value: 't', label: 'Total'}]} />
-        < CountrySelect selectOptions={this.state.countries}/>
-        < CountrySelect selectOptions={this.state.countries}/>
-        < CountrySelect selectOptions={this.state.countries}/>
+        < CountrySelect
+          selectOptions={[this.state.defaultCountry]}
+          disabled={true}
+        />
+        < CountrySelect
+          selectOptions={[{value: 't', label: 'Total'}]}
+          disabled={true}
+        />
+        < CountrySelect
+          selectOptions={this.state.countries}
+          onchange={this.updateValue1}
+          selectedCountries={this.state.selected1}
+        />
+        < CountrySelect
+          selectOptions={this.state.countries}
+          onchange={this.updateValue2}
+          selectedCountries={this.state.selected2}
+        />
+        < CountrySelect
+          selectOptions={this.state.countries}
+          onchange={this.updateValue3}
+          selectedCountries={this.state.selected3}
+        />
       </div>
     );
   }
@@ -102,16 +147,22 @@ export class CountrySelect extends Component {
 
   render() {
     let options = this.props.selectOptions
+    let update = this.props.onchange
+    let selectedCountries = this.props.selectedCountries
+    let disabled = this.props.disabled
     const style = { width: "20%", display: "inline", float: "left" }
     return (
       <div style={style}>
         <Select
           name="countries"
+          value={selectedCountries || options[0]}
           options={options}
+          onChange={update}
+          disabled={disabled}
         />
       </div>
     );
   }
 }
 
-// export default CountryPerformanceOnRisk;
+export default CountryPerformanceOnRisk;

--- a/src/index.js
+++ b/src/index.js
@@ -11,32 +11,54 @@ let xValues = ['2017-01-01','2017-01-08','2017-01-15'];
 let reduxStore = {
   graphs: {
     1: {
-      title: 'DDOS-graph',
-      dataToshow: ['t1','t2'],
+      title: 'dns-graph',
+      dataToshow: ['uk1','t1'],
       graphLayout: ['l1']
     }
   },
   entities: {
     data: [
       {
+        id: 'uk1',
         x: xValues,
         y: [2,4,6],
-        name: 'example N1',
+        name: 'United Kingdom',
         type: 'scatter'
       },
       {
+        id: 't1',
         x: xValues,
         y: [1,4,7],
-        name: 'example N2',
+        name: 'Global',
+        type: 'scatter'
+      },
+      {
+        id: 'us1',
+        x: xValues,
+        y: [6,3,2],
+        name: 'United States',
+        type: 'scatter'
+      },
+      {
+        id: 'ge1',
+        x: xValues,
+        y: [5,12,1],
+        name: 'Georgia',
+        type: 'scatter'
+      },
+      {
+        id: 'kz1',
+        x: xValues,
+        y: [0,12,10],
+        name: 'Kazakstan',
         type: 'scatter'
       }
     ],
     layouts: {
       l1: {
-        title : 'Global DDOS potential',
+        title : 'Open DNS',
         height: 600,
         xaxis: {
-          title: '*This chart assumes an average 1 mbit/sec Internet connection for every IP address.',
           gridcolor: 'transparent',
         },
         yaxis: {
@@ -49,12 +71,31 @@ let reduxStore = {
       {value: 'uk', label: 'United Kingdom' },
       {value: 'us', label: 'United States' },
       {value: 'ge', label: 'Georgia' },
+      {value: 'kz', label: 'Kazakhstan' }
     ]
   },
   defaultCountry: {value: 'uk', label: 'United Kingdom' }
 }
 const reducer = function(state, action) {
+  // makes new copy of list, for not to mutate previous state
+  let newDataToShow = state.graphs[1].dataToshow
+  newDataToShow[action.idx] = action.id
+
   switch(action.type) {
+    case 'addRemoveLine':
+      return {...state,
+        graphs: {
+          1: {
+            title: 'dns-graph',
+            dataToshow: Object.assign(
+              [],
+              state.graphs[1].dataToshow,
+              newDataToShow
+            ),
+            graphLayout: ['l1']
+          }
+        }
+      }
     default:
       return state
   }

--- a/src/index.js
+++ b/src/index.js
@@ -76,7 +76,8 @@ let reduxStore = {
   },
   defaultCountry: {value: 'uk', label: 'United Kingdom' }
 }
-const reducer = function(state, action) {
+
+const reducer = (state, action) => {
   // makes new copy of list, for not to mutate previous state
   let newDataToShow = state.graphs[1].dataToshow
   newDataToShow[action.idx] = action.id
@@ -100,6 +101,7 @@ const reducer = function(state, action) {
       return state
   }
 }
+
 let store = createStore(reducer, reduxStore)
 
 ReactDOM.render(

--- a/src/index.js
+++ b/src/index.js
@@ -1,11 +1,69 @@
 /* global graphData */
 import React from 'react';
 import ReactDOM from 'react-dom';
+import { createStore } from 'redux'
+import { Provider } from 'react-redux'
+
 import CountryPerformanceOnRisk from './components/CountryPerformanceOnRisk';
 
 
-// graphData (List of urls to API endpoints) should be passed from server
+let xValues = ['2017-01-01','2017-01-08','2017-01-15'];
+let reduxStore = {
+  graphs: {
+    1: {
+      title: 'DDOS-graph',
+      dataToshow: ['t1','t2'],
+      graphLayout: ['l1']
+    }
+  },
+  entities: {
+    data: [
+      {
+        x: xValues,
+        y: [2,4,6],
+        name: 'example N1',
+        type: 'scatter'
+      },
+      {
+        x: xValues,
+        y: [1,4,7],
+        name: 'example N2',
+        type: 'scatter'
+      }
+    ],
+    layouts: {
+      l1: {
+        title : 'Global DDOS potential',
+        height: 600,
+        xaxis: {
+          title: '*This chart assumes an average 1 mbit/sec Internet connection for every IP address.',
+          gridcolor: 'transparent',
+        },
+        yaxis: {
+          title: 'GBit/sec'
+        }
+      }
+    },
+    countries: [
+      {value: '', label: 'Select a country'},
+      {value: 'uk', label: 'United Kingdom' },
+      {value: 'us', label: 'United States' },
+      {value: 'ge', label: 'Georgia' },
+    ]
+  },
+  defaultCountry: {value: 'uk', label: 'United Kingdom' }
+}
+const reducer = function(state, action) {
+  switch(action.type) {
+    default:
+      return state
+  }
+}
+let store = createStore(reducer, reduxStore)
+
 ReactDOM.render(
-  <CountryPerformanceOnRisk urls={graphData || []}/>,
+  <Provider store={store}>
+    <CountryPerformanceOnRisk/>
+  </Provider>,
   document.getElementById('root')
 );

--- a/tests/CountryPerformanceOnRisk.component.test.js
+++ b/tests/CountryPerformanceOnRisk.component.test.js
@@ -1,6 +1,7 @@
-import CountryPerformanceOnRisk from '../src/components/CountryPerformanceOnRisk.js'
+import {CountryPerformanceOnRisk, CountrySelect } from '../src/components/CountryPerformanceOnRisk.js'
 import React from 'react'
 import {shallow} from 'enzyme'
+import toJson from 'enzyme-to-json';
 
 
 describe('Components are working fine', () => {
@@ -10,36 +11,18 @@ describe('Components are working fine', () => {
     let out = wrapper.instance().computeState()
     expect(out.hasOwnProperty('data')).toBeTruthy()
     expect(out.hasOwnProperty('graphOptions')).toBeTruthy()
-    expect(out.hasOwnProperty('matchedCountry')).toBeTruthy()
-    expect(out.hasOwnProperty('countries')).toBeTruthy()
   })
 
-  it('Div with id plot is there', () => {
+  it('Div with id DDOS-graph is there', () => {
     const wrapper = shallow(< CountryPerformanceOnRisk />)
-    wrapper.setState(wrapper.instance().computeState())
-    expect(wrapper.html()).toContain('<div id="DDOS-graph"></div>')
+    expect(toJson(wrapper)).toMatchSnapshot();
   })
 
-  it('Input tag for search is there', () => {
-    const wrapper = shallow(< CountryPerformanceOnRisk />)
-    wrapper.setState(wrapper.instance().computeState())
-    expect(wrapper.html()).toContain('<input type="text" placeholder="Search.."/>')
-  })
+})
 
-  it('handleSearch works', () => {
-    const wrapper = shallow(< CountryPerformanceOnRisk />)
-    wrapper.setState({ countries: [
-      {id: 'uk', name: 'United Kingdom'},
-      {id: 'us', name: 'United States'}
-    ]})
-    let event = {target: {value: 'u'}}
-    let out = wrapper.instance().handleSearch(event)
-    expect(wrapper.state().matchedCountry.length).toEqual(2)
-    expect(wrapper.state().matchedCountry[0].id).toEqual('uk')
-    expect(wrapper.state().matchedCountry[1].id).toEqual('us')
-    event = {target: {value: 'k'}}
-    out = wrapper.instance().handleSearch(event)
-    expect(wrapper.state().matchedCountry[0].id).toEqual('uk')
-    expect(wrapper.state().matchedCountry.length).toEqual(1)
+describe('Country Select', () => {
+  it('Dropdown is there', () => {
+    const wrapper = shallow(< CountrySelect selectOptions={[]}/>)
+    expect(toJson(wrapper)).toMatchSnapshot();
   })
 })

--- a/tests/CountryPerformanceOnRisk.component.test.js
+++ b/tests/CountryPerformanceOnRisk.component.test.js
@@ -1,6 +1,8 @@
-import {CountryPerformanceOnRisk, CountrySelect } from '../src/components/CountryPerformanceOnRisk.js'
-import React from 'react'
-import {shallow} from 'enzyme'
+import { CountryPerformanceOnRisk, CountrySelect }
+from '../src/components/CountryPerformanceOnRisk.js';
+import React from 'react';
+import { Provider } from 'react-redux';
+import {shallow} from 'enzyme';
 import toJson from 'enzyme-to-json';
 
 
@@ -17,11 +19,52 @@ describe('Components are working fine', () => {
     expect(toJson(wrapper)).toMatchSnapshot();
   })
 
+  it('When a country is selected, it updates state of the container', () => {
+    function stub() {return ''}
+    const wrapper = shallow(< CountryPerformanceOnRisk dispatch={stub} />)
+    let newCountry = {value: 'us', label: 'United States'}
+    expect(wrapper.find('CountrySelect').at(2).props().selectedCountries)
+      .toEqual(undefined)
+    wrapper.find('CountrySelect').at(2).simulate('change', newCountry)
+    expect(wrapper.find('CountrySelect').at(2).props().selectedCountries)
+      .toEqual(newCountry)
+  })
+
 })
 
-describe('Country Select', () => {
+describe('Country Select component', () => {
+  function setup() {
+    let props = {
+      selectOptions: [
+        {value: '', label: 'Select a country'},
+        {value: 'uk', label: 'United Kingdom' }
+      ],
+      onChange: jest.fn(),
+      selectedCountries: undefined
+    }
+
+    const enzymeWrapper = shallow(< CountrySelect {...props} />)
+
+    return {
+      props,
+      enzymeWrapper
+    }
+  }
+
   it('Dropdown is there', () => {
     const wrapper = shallow(< CountrySelect selectOptions={[]}/>)
     expect(toJson(wrapper)).toMatchSnapshot();
+  })
+
+  it('Selecting a country triggers event on parent component', () => {
+    const { enzymeWrapper, props } = setup()
+    const selector = enzymeWrapper.find('Select')
+    expect(selector.props().value).toEqual({
+      "label": "Select a country", "value": ""
+    })
+    let selectedOption = {value: 'uk', label: 'United Kingdom' }
+    selector.props().onChange(selectedOption)
+    expect(props.onChange.mock.calls.length).toEqual(1)
+    expect(props.onChange.mock.calls[0][0]).toEqual(selectedOption)
   })
 })

--- a/tests/CountryPerformanceOnRisk.component.test.js
+++ b/tests/CountryPerformanceOnRisk.component.test.js
@@ -7,10 +7,9 @@ import toJson from 'enzyme-to-json';
 describe('Components are working fine', () => {
 
   it('computeState works', () => {
-    const wrapper = shallow(< CountryPerformanceOnRisk />)
+    const wrapper = shallow(< CountryPerformanceOnRisk data={['Is Working']}/>)
     let out = wrapper.instance().computeState()
-    expect(out.hasOwnProperty('data')).toBeTruthy()
-    expect(out.hasOwnProperty('graphOptions')).toBeTruthy()
+    expect(out.data).toEqual(['Is Working'])
   })
 
   it('Div with id DDOS-graph is there', () => {

--- a/tests/CountryPerformanceOnRisk.component.test.js
+++ b/tests/CountryPerformanceOnRisk.component.test.js
@@ -1,7 +1,6 @@
 import { CountryPerformanceOnRisk, CountrySelect }
 from '../src/components/CountryPerformanceOnRisk.js';
 import React from 'react';
-import { Provider } from 'react-redux';
 import {shallow} from 'enzyme';
 import toJson from 'enzyme-to-json';
 
@@ -23,10 +22,10 @@ describe('Components are working fine', () => {
     function stub() {return ''}
     const wrapper = shallow(< CountryPerformanceOnRisk dispatch={stub} />)
     let newCountry = {value: 'us', label: 'United States'}
-    expect(wrapper.find('CountrySelect').at(2).props().selectedCountries)
+    expect(wrapper.find('CountrySelect').at(2).props().selectedCountry)
       .toEqual(undefined)
     wrapper.find('CountrySelect').at(2).simulate('change', newCountry)
-    expect(wrapper.find('CountrySelect').at(2).props().selectedCountries)
+    expect(wrapper.find('CountrySelect').at(2).props().selectedCountry)
       .toEqual(newCountry)
   })
 
@@ -40,7 +39,7 @@ describe('Country Select component', () => {
         {value: 'uk', label: 'United Kingdom' }
       ],
       onChange: jest.fn(),
-      selectedCountries: undefined
+      selectedCountry: undefined
     }
 
     const enzymeWrapper = shallow(< CountrySelect {...props} />)
@@ -52,8 +51,8 @@ describe('Country Select component', () => {
   }
 
   it('Dropdown is there', () => {
-    const wrapper = shallow(< CountrySelect selectOptions={[]}/>)
-    expect(toJson(wrapper)).toMatchSnapshot();
+    const { enzymeWrapper } = setup()
+    expect(toJson(enzymeWrapper)).toMatchSnapshot();
   })
 
   it('Selecting a country triggers event on parent component', () => {

--- a/tests/__snapshots__/CountryPerformanceOnRisk.component.test.js.snap
+++ b/tests/__snapshots__/CountryPerformanceOnRisk.component.test.js.snap
@@ -5,12 +5,14 @@ exports[`Components are working fine Div with id DDOS-graph is there 1`] = `
     graphID="DDOS-graph"
     graphOptions={Object {}} />
   <CountrySelect
+    disabled={true}
     selectOptions={
       Array [
         Object {},
       ]
     } />
   <CountrySelect
+    disabled={true}
     selectOptions={
       Array [
         Object {
@@ -20,10 +22,13 @@ exports[`Components are working fine Div with id DDOS-graph is there 1`] = `
       ]
     } />
   <CountrySelect
+    onchange={[Function]}
     selectOptions={Array []} />
   <CountrySelect
+    onchange={[Function]}
     selectOptions={Array []} />
   <CountrySelect
+    onchange={[Function]}
     selectOptions={Array []} />
 </div>
 `;

--- a/tests/__snapshots__/CountryPerformanceOnRisk.component.test.js.snap
+++ b/tests/__snapshots__/CountryPerformanceOnRisk.component.test.js.snap
@@ -16,7 +16,7 @@ exports[`Components are working fine Div with id DDOS-graph is there 1`] = `
     selectOptions={
       Array [
         Object {
-          "label": "Total",
+          "label": "Global",
           "value": "t",
         },
       ]
@@ -71,10 +71,22 @@ exports[`Country Select component Dropdown is there 1`] = `
     name="countries"
     noResultsText="No results found"
     onBlurResetsInput={true}
+    onChange={[Function]}
     onCloseResetsInput={true}
     openAfterFocus={false}
     optionComponent={[Function]}
-    options={Array []}
+    options={
+      Array [
+        Object {
+          "label": "Select a country",
+          "value": "",
+        },
+        Object {
+          "label": "United Kingdom",
+          "value": "uk",
+        },
+      ]
+    }
     pageSize={5}
     placeholder="Select..."
     required={false}
@@ -82,6 +94,12 @@ exports[`Country Select component Dropdown is there 1`] = `
     searchable={true}
     simpleValue={false}
     tabSelectsValue={true}
+    value={
+      Object {
+        "label": "Select a country",
+        "value": "",
+      }
+    }
     valueComponent={[Function]}
     valueKey="value" />
 </div>

--- a/tests/__snapshots__/CountryPerformanceOnRisk.component.test.js.snap
+++ b/tests/__snapshots__/CountryPerformanceOnRisk.component.test.js.snap
@@ -22,18 +22,18 @@ exports[`Components are working fine Div with id DDOS-graph is there 1`] = `
       ]
     } />
   <CountrySelect
-    onchange={[Function]}
+    onChange={[Function]}
     selectOptions={Array []} />
   <CountrySelect
-    onchange={[Function]}
+    onChange={[Function]}
     selectOptions={Array []} />
   <CountrySelect
-    onchange={[Function]}
+    onChange={[Function]}
     selectOptions={Array []} />
 </div>
 `;
 
-exports[`Country Select Dropdown is there 1`] = `
+exports[`Country Select component Dropdown is there 1`] = `
 <div
   style={
     Object {

--- a/tests/__snapshots__/CountryPerformanceOnRisk.component.test.js.snap
+++ b/tests/__snapshots__/CountryPerformanceOnRisk.component.test.js.snap
@@ -1,0 +1,83 @@
+exports[`Components are working fine Div with id DDOS-graph is there 1`] = `
+<div>
+  <PlotlyGraph
+    data={Array []}
+    graphID="DDOS-graph"
+    graphOptions={Object {}} />
+  <CountrySelect
+    selectOptions={
+      Array [
+        Object {},
+      ]
+    } />
+  <CountrySelect
+    selectOptions={
+      Array [
+        Object {
+          "label": "Total",
+          "value": "t",
+        },
+      ]
+    } />
+  <CountrySelect
+    selectOptions={Array []} />
+  <CountrySelect
+    selectOptions={Array []} />
+  <CountrySelect
+    selectOptions={Array []} />
+</div>
+`;
+
+exports[`Country Select Dropdown is there 1`] = `
+<div
+  style={
+    Object {
+      "display": "inline",
+      "float": "left",
+      "width": "20%",
+    }
+  }>
+  <Select
+    addLabelText="Add \"{label}\"?"
+    arrowRenderer={[Function]}
+    autosize={true}
+    backspaceRemoves={true}
+    backspaceToRemoveMessage="Press backspace to remove {label}"
+    clearAllText="Clear all"
+    clearRenderer={[Function]}
+    clearValueText="Clear value"
+    clearable={true}
+    deleteRemoves={true}
+    delimiter=","
+    disabled={false}
+    escapeClearsValue={true}
+    filterOptions={[Function]}
+    ignoreAccents={true}
+    ignoreCase={true}
+    inputProps={Object {}}
+    isLoading={false}
+    joinValues={false}
+    labelKey="label"
+    matchPos="any"
+    matchProp="any"
+    menuBuffer={0}
+    menuRenderer={[Function]}
+    multi={false}
+    name="countries"
+    noResultsText="No results found"
+    onBlurResetsInput={true}
+    onCloseResetsInput={true}
+    openAfterFocus={false}
+    optionComponent={[Function]}
+    options={Array []}
+    pageSize={5}
+    placeholder="Select..."
+    required={false}
+    scrollMenuIntoView={true}
+    searchable={true}
+    simpleValue={false}
+    tabSelectsValue={true}
+    valueComponent={[Function]}
+    valueKey="value" />
+</div>
+`;


### PR DESCRIPTION
This PR makes it possible for graphs to select country from 3 different drop down menus and add or remove data for selected country.

Thought selecting/removing is done IMHO in a quite hacky way, this is the only way we found solution to handle changing countries from 3 different dropdowns and not mass with each other. 

This PR is introducing the Redux store in application and using mocked up action and reducer to handle inserting and removing lines from graph. This is happening in `CountryPerformanceOnRisk` component

As `CountryPerformanceOnRisk` has become "smart" component and is handling graph modification, testing this becomes harder. This PR does include thorough (partially) tests checking weather onchange methods are called and state is updated. (meaning line is added to the graph)
Testing smart component seems harder then expected. This may be helpful - https://github.com/reactjs/redux/issues/588

Besides this PR includes:
- 5 selctors available under graph. Using [react-select](https://github.com/JedWatson/react-select) library
- Test using snapshot testing
- 2 non-editable selectors and 3 other, listing countries passed from redux store. 
- Mocked up redux store inside main `index.js` file with mocked up reducer (responsible for adding/removing)
- Test for onchange methods and store udpates