### PR TITLE
 Setup new store architecture and load async data

### DIFF
--- a/src/actions/cubeActions.js
+++ b/src/actions/cubeActions.js
@@ -1,0 +1,39 @@
+import axios from 'axios'
+
+export const FETCH_DATA_REQUEST = 'FETCH_DATA_REQUEST'
+function requestData(country, risk) {
+  return {
+    type: FETCH_DATA_REQUEST,
+    country,
+    risk
+  }
+}
+
+export const FETCH_DATA_SUCCESS = 'FETCH_DATA_SUCCESS'
+function receivetData(data, country, risk) {
+  return {
+    type: FETCH_DATA_SUCCESS,
+    data,
+    country,
+    risk
+  }
+}
+
+export const FETCH_DATA_FAILURE = 'FETCH_DATA_FAILURE'
+function receivetDataFailure(message, country, risk) {
+  return {
+    type: FETCH_DATA_FAILURE,
+    error: message,
+    country,
+    risk
+  }
+}
+
+export function fetchData(country, risk) {
+  return function(dispatch) {
+    dispatch(requestData(country, risk))
+    return axios.get(`/api/count_by_country?limit=500&country=${country}&risk=${risk}`)
+      .then(res => dispatch(receivetData(res.data.results, country, risk)))
+      .catch(err => dispatch(receivetDataFailure(err.message, country, risk)))
+  }
+}

--- a/src/actions/cubeActions.js
+++ b/src/actions/cubeActions.js
@@ -29,10 +29,23 @@ function receivetDataFailure(message, country, risk) {
   }
 }
 
+export const SELECT = 'SELECT'
+export function countryIsSelected(idxOfSelector, selectedCountry) {
+  return {
+    type: SELECT,
+    idxOfSelector,
+    selectedCountry
+  }
+}
+
 export function fetchData(country, risk) {
   return function(dispatch) {
     dispatch(requestData(country, risk))
-    return axios.get(`/api/count_by_country?limit=500&country=${country}&risk=${risk}`)
+    let url = `/api/count_by_country?limit=500&country=${country}&risk=${risk}`
+    // uncomment below to load live data for developent
+    // you might need to enable cross-origin resource sharing
+    // url = `https://cybergreen-staging.herokuapp.com/api/v1/count_by_country?limit=500&country=${country}&risk=${risk}`
+    return axios.get(url)
       .then(res => dispatch(receivetData(res.data.results, country, risk)))
       .catch(err => dispatch(receivetDataFailure(err.message, country, risk)))
   }

--- a/src/components/CountryPerformanceOnRisk.js
+++ b/src/components/CountryPerformanceOnRisk.js
@@ -114,7 +114,12 @@ const mapStateToProps = (state) => {
       return state.graphs[1].dataToshow.indexOf(data.id) !== -1
     }),
     graphOptions: state.entities.layouts,
-    countries: state.entities.countries,
+    countries: Object.keys(state.entities.countries).map(countryID => {
+      return {
+        value: countryID.toLowerCase(),
+        label: state.entities.countries[countryID].title
+      }
+    }),
     defaultCountry: state.defaultCountry
   }
 }

--- a/src/components/CountryPerformanceOnRisk.js
+++ b/src/components/CountryPerformanceOnRisk.js
@@ -13,7 +13,8 @@ export class CountryPerformanceOnRisk extends Component {
       graphOptions: {},
       defaultCountry: '',
       countries: {},
-      selectorConfig: []
+      selectorConfig: [],
+      plotlyData: []
     }
   }
 

--- a/src/components/CountryPerformanceOnRisk.js
+++ b/src/components/CountryPerformanceOnRisk.js
@@ -3,6 +3,7 @@ import { connect } from 'react-redux'
 import PlotlyGraph from './Plot.js';
 import Select from 'react-select';
 import 'react-select/dist/react-select.css';
+import { countryIsSelected, fetchData } from '../actions/cubeActions';
 
 
 export class CountryPerformanceOnRisk extends Component {
@@ -20,6 +21,10 @@ export class CountryPerformanceOnRisk extends Component {
 
 
   computeState(props=this.props) {
+    if (props.views[1].errorMessage) {
+      console.log('Error: '+props.views[1].errorMessage)
+      console.log('Try to comment out line 47 in cubeActions.js')
+    }
     let countries = []
     if (props.countries) {
       countries = Object.keys(props.countries).map(countryID => {
@@ -31,7 +36,7 @@ export class CountryPerformanceOnRisk extends Component {
     }
 
     let plotlyData = []
-    if (props.cubeByRiskByCountry) {
+    if (props.views[1].isFetched) {
       plotlyData = props.views[1].selectorConfig.map(config => {
         if (config.country){
           return this.convertToPlotlySeries(config.country, 1, props.cubeByRiskByCountry)
@@ -46,8 +51,7 @@ export class CountryPerformanceOnRisk extends Component {
       plotlyData: plotlyData,
       defaultCountry: props.views[1].country,
       selectorConfig: props.views[1].selectorConfig
-     }
-
+    }
     return state
   }
 
@@ -64,6 +68,14 @@ export class CountryPerformanceOnRisk extends Component {
 
 
   componentDidMount() {
+    this.props.dispatch(fetchData(
+      this.props.views[1].country,
+      this.props.views[1].risk
+    ))
+    this.props.dispatch(fetchData(
+      't',
+      this.props.views[1].risk
+    ))
     this.setState(this.computeState(this.props))
   };
 
@@ -75,16 +87,8 @@ export class CountryPerformanceOnRisk extends Component {
 
   updateValue(idxOfSelector, selectedCountry) {
     selectedCountry = selectedCountry || { value: "" }
-    this.props.dispatch(this.countryIsSelected(idxOfSelector, selectedCountry.value))
-  }
-
-
-  countryIsSelected(idxOfSelector, selectedCountry) {
-    return {
-      type: 'SELECT',
-      idxOfSelector,
-      selectedCountry
-    }
+    this.props.dispatch(countryIsSelected(idxOfSelector, selectedCountry.value))
+    this.props.dispatch(fetchData(selectedCountry.value,this.props.views[1].risk))
   }
 
 

--- a/src/index.js
+++ b/src/index.js
@@ -9,21 +9,14 @@ import CountryPerformanceOnRisk from './components/CountryPerformanceOnRisk';
 
 let xValues = ['2017-01-01','2017-01-08','2017-01-15'];
 let reduxStore = {
-  graphs: {
-    1: {
-      title: 'dns-graph',
-      dataToshow: ['uk1','t1'],
-      graphLayout: ['l1']
-    }
-  },
   entities: {
     countries: {
       '': {title: 'Select a country'},
-      'T': {title: 'Global'},
-      'GE': {title: 'Georgia'},
-      'KZ': {title: 'Kazakhstan'},
-      'UK': {title: 'United Kingdom'},
-      'US': {title: 'United States'}
+      't': {title: 'Global'},
+      'ge': {title: 'Georgia'},
+      'kz': {title: 'Kazakhstan'},
+      'gb': {title: 'United Kingdom'},
+      'us': {title: 'United States'}
     },
     risks: {
       1: {title: 'Open DNS'},
@@ -33,43 +26,80 @@ let reduxStore = {
       6: {title: 'Open Mirai'},
       100: {title: 'DDOS'}
     },
-    data: [
-      {
-        id: 'uk1',
-        x: xValues,
-        y: [2,4,6],
-        name: 'United Kingdom',
-        type: 'scatter'
-      },
-      {
-        id: 't1',
-        x: xValues,
-        y: [1,4,7],
-        name: 'Global',
-        type: 'scatter'
-      },
-      {
-        id: 'us1',
-        x: xValues,
-        y: [6,3,2],
-        name: 'United States',
-        type: 'scatter'
-      },
-      {
-        id: 'ge1',
-        x: xValues,
-        y: [5,12,1],
-        name: 'Georgia',
-        type: 'scatter'
-      },
-      {
-        id: 'kz1',
-        x: xValues,
-        y: [0,12,10],
-        name: 'Kazakstan',
-        type: 'scatter'
+    cubeByRiskByCountry: {
+      1: {
+        gb: [
+          {
+            "risk": 1,"country": "GB","date": "2017-01-16",
+            "count": "11506","count_amplified": 4571746
+          },
+          {
+            "risk": 1,"country": "GB","date": "2017-01-09",
+            "count": "13330","count_amplified": 4646530
+          },
+          {
+            "risk": 1,"country": "GB","date": "2017-01-02",
+            "count": "11471","count_amplified": 4570311
+          }
+        ],
+        ge: [
+          {
+            "risk": 1,"country": "GE","date": "2017-01-16",
+            "count": "25712","count_amplified": 234192
+          },
+          {
+            "risk": 1,"country": "GE","date": "2017-01-09",
+            "count": "15898","count_amplified": 241818
+          },
+          {
+            "risk": 1,"country": "GE","date": "2017-01-02",
+            "count": "6324","count_amplified": 259284
+          }
+        ],
+        kz: [
+          {
+            "risk": 1,"country": "KZ","date": "2017-01-16",
+            "count": "29399","count_amplified": 1205359
+          },
+          {
+            "risk": 1,"country": "KZ","date": "2017-01-09",
+            "count": "30580","count_amplified": 1253780
+          },
+          {
+            "risk": 1,"country": "KZ","date": "2017-01-02",
+            "count": "27083","count_amplified": 1110403
+          }
+        ],
+        us: [
+          {
+            "risk": 1,"country": "US","date": "2017-01-16",
+            "count": "82772","count_amplified": 35373652
+          },
+          {
+            "risk": 1,"country": "US","date": "2017-01-09",
+            "count": "56717","count_amplified": 35125397
+          },
+          {
+            "risk": 1,"country": "US","date": "2017-01-02",
+            "count": "66268","count_amplified": 35516988
+          },
+        ],
+        t: [
+          {
+            "risk": 1,"country": "T","date": "2017-01-16",
+            "count": "81548","count_amplified": 156434762
+          },
+          {
+            "risk": 1,"country": "T","date": "2017-01-09",
+            "count": "33172","count_amplified": 157100602
+          },
+          {
+            "risk": 1,"country": "T","date": "2017-01-02",
+            "count": "32558","count_amplified": 156849067
+          }
+        ]
       }
-    ],
+    },
     layouts: {
       l1: {
         title : 'Open DNS',
@@ -83,32 +113,11 @@ let reduxStore = {
       }
     }
   },
-  defaultCountry: {value: 'uk', label: 'United Kingdom' }
+  defaultCountry: {value: 'gb', label: 'United Kingdom' }
 }
 
 const reducer = (state, action) => {
-  // makes new copy of list, for not to mutate previous state
-  let newDataToShow = state.graphs[1].dataToshow
-  newDataToShow[action.idx] = action.id
-
-  switch(action.type) {
-    case 'addRemoveLine':
-      return {...state,
-        graphs: {
-          1: {
-            title: 'dns-graph',
-            dataToshow: Object.assign(
-              [],
-              state.graphs[1].dataToshow,
-              newDataToShow
-            ),
-            graphLayout: ['l1']
-          }
-        }
-      }
-    default:
-      return state
-  }
+  return state
 }
 
 let store = createStore(reducer, reduxStore)

--- a/src/index.js
+++ b/src/index.js
@@ -17,6 +17,22 @@ let reduxStore = {
     }
   },
   entities: {
+    countries: {
+      '': {title: 'Select a country'},
+      'T': {title: 'Global'},
+      'GE': {title: 'Georgia'},
+      'KZ': {title: 'Kazakhstan'},
+      'UK': {title: 'United Kingdom'},
+      'US': {title: 'United States'}
+    },
+    risks: {
+      1: {title: 'Open DNS'},
+      2: {title: 'Open NTP'},
+      4: {title: 'Open SNMP'},
+      5: {title: 'Open SSDP'},
+      6: {title: 'Open Mirai'},
+      100: {title: 'DDOS'}
+    },
     data: [
       {
         id: 'uk1',
@@ -65,14 +81,7 @@ let reduxStore = {
           title: 'GBit/sec'
         }
       }
-    },
-    countries: [
-      {value: '', label: 'Select a country'},
-      {value: 'uk', label: 'United Kingdom' },
-      {value: 'us', label: 'United States' },
-      {value: 'ge', label: 'Georgia' },
-      {value: 'kz', label: 'Kazakhstan' }
-    ]
+    }
   },
   defaultCountry: {value: 'uk', label: 'United Kingdom' }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,8 +1,10 @@
 /* global graphData */
 import React from 'react';
 import ReactDOM from 'react-dom';
-import { createStore } from 'redux'
-import { Provider } from 'react-redux'
+import { createStore, applyMiddleware } from 'redux';
+import thunk from 'redux-thunk';
+import { Provider } from 'react-redux';
+import { buildCube } from './reducers/cubeReducers';
 
 import CountryPerformanceOnRisk from './components/CountryPerformanceOnRisk';
 
@@ -25,80 +27,7 @@ let reduxStore = {
       6: {title: 'Open Mirai'},
       100: {title: 'DDOS'}
     },
-    cubeByRiskByCountry: {
-      1: {
-        gb: [
-          {
-            "risk": 1,"country": "GB","date": "2017-01-16",
-            "count": "11506","count_amplified": 4571746
-          },
-          {
-            "risk": 1,"country": "GB","date": "2017-01-09",
-            "count": "13330","count_amplified": 4646530
-          },
-          {
-            "risk": 1,"country": "GB","date": "2017-01-02",
-            "count": "11471","count_amplified": 4570311
-          }
-        ],
-        ge: [
-          {
-            "risk": 1,"country": "GE","date": "2017-01-16",
-            "count": "25712","count_amplified": 234192
-          },
-          {
-            "risk": 1,"country": "GE","date": "2017-01-09",
-            "count": "15898","count_amplified": 241818
-          },
-          {
-            "risk": 1,"country": "GE","date": "2017-01-02",
-            "count": "6324","count_amplified": 259284
-          }
-        ],
-        kz: [
-          {
-            "risk": 1,"country": "KZ","date": "2017-01-16",
-            "count": "29399","count_amplified": 1205359
-          },
-          {
-            "risk": 1,"country": "KZ","date": "2017-01-09",
-            "count": "30580","count_amplified": 1253780
-          },
-          {
-            "risk": 1,"country": "KZ","date": "2017-01-02",
-            "count": "27083","count_amplified": 1110403
-          }
-        ],
-        us: [
-          {
-            "risk": 1,"country": "US","date": "2017-01-16",
-            "count": "82772","count_amplified": 35373652
-          },
-          {
-            "risk": 1,"country": "US","date": "2017-01-09",
-            "count": "56717","count_amplified": 35125397
-          },
-          {
-            "risk": 1,"country": "US","date": "2017-01-02",
-            "count": "66268","count_amplified": 35516988
-          },
-        ],
-        t: [
-          {
-            "risk": 1,"country": "T","date": "2017-01-16",
-            "count": "81548","count_amplified": 156434762
-          },
-          {
-            "risk": 1,"country": "T","date": "2017-01-09",
-            "count": "33172","count_amplified": 157100602
-          },
-          {
-            "risk": 1,"country": "T","date": "2017-01-02",
-            "count": "32558","count_amplified": 156849067
-          }
-        ]
-      }
-    },
+    cubeByRiskByCountry: {},
     layouts: {
       l1: {
         title : 'Open DNS',
@@ -117,6 +46,9 @@ let reduxStore = {
       type: "country/performance",
       country: "gb",
       risk: 1,
+      isFetched: false,
+      isFetching: false,
+      didFailed: false,
       selectorConfig: [
         {disabled: true, country: "gb"},
         {disabled: true, country: "t"},
@@ -129,25 +61,11 @@ let reduxStore = {
 }
 
 
-const reducer = (state, action) => {
-  switch(action.type) {
-    case 'SELECT':
-      let newSelectorConfig = state.views["1"].selectorConfig.slice()
-      newSelectorConfig[action.idxOfSelector].country = action.selectedCountry
-      return {
-        ...state,
-        views: {
-          1: {
-            selectorConfig: newSelectorConfig
-          }
-        }
-      }
-    default:
-      return state
-  }
-}
-
-let store = createStore(reducer, reduxStore)
+let store = createStore(
+  buildCube,
+  reduxStore,
+  applyMiddleware(thunk)
+)
 
 ReactDOM.render(
   <Provider store={store}>

--- a/src/index.js
+++ b/src/index.js
@@ -7,7 +7,6 @@ import { Provider } from 'react-redux'
 import CountryPerformanceOnRisk from './components/CountryPerformanceOnRisk';
 
 
-let xValues = ['2017-01-01','2017-01-08','2017-01-15'];
 let reduxStore = {
   entities: {
     countries: {
@@ -113,11 +112,39 @@ let reduxStore = {
       }
     }
   },
-  defaultCountry: {value: 'gb', label: 'United Kingdom' }
+  views: {
+    1: {
+      type: "country/performance",
+      country: "gb",
+      risk: 1,
+      selectorConfig: [
+        {disabled: true, country: "gb"},
+        {disabled: true, country: "t"},
+        {disabled: false, country: undefined},
+        {disabled: false, country: undefined},
+        {disabled: false, country: undefined}
+      ]
+    }
+  }
 }
 
+
 const reducer = (state, action) => {
-  return state
+  switch(action.type) {
+    case 'SELECT':
+      let newSelectorConfig = state.views["1"].selectorConfig.slice()
+      newSelectorConfig[action.idxOfSelector].country = action.selectedCountry
+      return {
+        ...state,
+        views: {
+          1: {
+            selectorConfig: newSelectorConfig
+          }
+        }
+      }
+    default:
+      return state
+  }
 }
 
 let store = createStore(reducer, reduxStore)

--- a/src/reducers/cubeReducers.js
+++ b/src/reducers/cubeReducers.js
@@ -1,43 +1,57 @@
+import update from 'react/lib/update'
 import {
-  FETCH_DATA_REQUEST, FETCH_DATA_SUCCESS, FETCH_DATA_FAILURE
+  FETCH_DATA_REQUEST, FETCH_DATA_SUCCESS, FETCH_DATA_FAILURE, SELECT
 } from '../actions/cubeActions';
 
-export function buildCube(state, action) {
+const initialState = {
+  entities: {
+    countries: {},
+    risks: {},
+    cubeByRiskByCountry: {}
+  },
+  views: { 1: {} }
+}
+
+export function buildCube(state=initialState, action) {
   switch (action.type) {
     case FETCH_DATA_FAILURE:
-      return Object.assign({}, state, {
-        views: Object.assign({}, state.views, { 1: {
-                type: 'country/performance',
-                risk: action.risk, country: action.country,
-                isFetched: false, isFetching: false, didFailed: true,
-                errorMessage: action.errorMessage
-                }
-              }
-            )
+      return update(state, {
+        views: {
+          1 :{
+            type: {$set: 'country/performance'},
+            risk: {$set: action.risk}, country: {$set: action.country},
+            isFetched: {$set: false},
+            isFetching: {$set: false},
+            didFailed: {$set: true},
+            errorMessage: {$set: action.error}
           }
-        )
+        }
+      })
     case FETCH_DATA_REQUEST:
-      return Object.assign({}, state, {
-        views: Object.assign({}, state.views, { 1: {
-                type: 'country/performance',
-                risk: action.risk, country: action.country,
-                isFetched: false, isFetching: true, didFailed: false,
-                }
-              }
-            )
+      return update(state, {
+        views: {
+          1 :{
+            type: {$set: 'country/performance'},
+            risk: {$set: action.risk}, country: {$set: action.country},
+            isFetched: {$set: false},
+            isFetching: {$set: true},
+            didFailed: {$set: false}
           }
-        )
+        }
+      })
     case FETCH_DATA_SUCCESS:
-      return Object.assign({}, state, {
-          views: Object.assign({}, state.views, { 1: {
-                type: 'country/performance',
-                risk: action.risk, country: action.country,
-                isFetched: true, isFetching: false, didFailed: false,
-              }
-            }
-          )
-        },
-        {
+      let newState = update(state, {
+        views: {
+          1 :{
+            type: {$set: 'country/performance'},
+            risk: {$set: action.risk}, country: {$set: action.country},
+            isFetched: {$set: true},
+            isFetching: {$set: false},
+            didFailed: {$set: false}
+          }
+        }
+      })
+      return Object.assign({}, newState, {
           entities: Object.assign(
               {}, state.entities, {
                 cubeByRiskByCountry: Object.assign(
@@ -51,6 +65,17 @@ export function buildCube(state, action) {
           )
         }
       )
+    case SELECT:
+      return update(state, {
+        views: {
+          1: {
+            selectorConfig: {
+              $splice: [[action.idxOfSelector, 1,{
+                disabled: false, country: action.selectedCountry
+              }]]}
+          }
+        }
+      })
     default:
       return state
   }

--- a/src/reducers/cubeReducers.js
+++ b/src/reducers/cubeReducers.js
@@ -1,0 +1,57 @@
+import {
+  FETCH_DATA_REQUEST, FETCH_DATA_SUCCESS, FETCH_DATA_FAILURE
+} from '../actions/cubeActions';
+
+export function buildCube(state, action) {
+  switch (action.type) {
+    case FETCH_DATA_FAILURE:
+      return Object.assign({}, state, {
+        views: Object.assign({}, state.views, { 1: {
+                type: 'country/performance',
+                risk: action.risk, country: action.country,
+                isFetched: false, isFetching: false, didFailed: true,
+                errorMessage: action.errorMessage
+                }
+              }
+            )
+          }
+        )
+    case FETCH_DATA_REQUEST:
+      return Object.assign({}, state, {
+        views: Object.assign({}, state.views, { 1: {
+                type: 'country/performance',
+                risk: action.risk, country: action.country,
+                isFetched: false, isFetching: true, didFailed: false,
+                }
+              }
+            )
+          }
+        )
+    case FETCH_DATA_SUCCESS:
+      return Object.assign({}, state, {
+          views: Object.assign({}, state.views, { 1: {
+                type: 'country/performance',
+                risk: action.risk, country: action.country,
+                isFetched: true, isFetching: false, didFailed: false,
+              }
+            }
+          )
+        },
+        {
+          entities: Object.assign(
+              {}, state.entities, {
+                cubeByRiskByCountry: Object.assign(
+                  {}, state.entities.cubeByRiskByCountry,{[action.risk]: Object.assign(
+                    {}, state.entities.cubeByRiskByCountry[action.risk], {
+                      [action.country]: action.data}
+                  )
+                }
+              )
+            }
+          )
+        }
+      )
+    default:
+      return state
+  }
+}

--- a/tests/CountryPerformanceOnRisk.component.test.js
+++ b/tests/CountryPerformanceOnRisk.component.test.js
@@ -1,33 +1,156 @@
 import { CountryPerformanceOnRisk, CountrySelect }
-from '../src/components/CountryPerformanceOnRisk.js';
+from '../src/components/CountryPerformanceOnRisk';
 import React from 'react';
 import {shallow} from 'enzyme';
 import toJson from 'enzyme-to-json';
 
 
 describe('Components are working fine', () => {
+  function setup() {
+    let props = {
+      dispatch: jest.fn(),
+      cubeByRiskByCountry: {
+        1: {
+          gb: [
+            {
+              "risk": 1,"country": "GB","date": "2017-01-16",
+              "count": "11506","count_amplified": 4571746
+            },
+            {
+              "risk": 1,"country": "GB","date": "2017-01-09",
+              "count": "13330","count_amplified": 4646530
+            },
+            {
+              "risk": 1,"country": "GB","date": "2017-01-02",
+              "count": "11471","count_amplified": 4570311
+            }
+          ],
+          ge: [
+            {
+              "risk": 1,"country": "GE","date": "2017-01-16",
+              "count": "25712","count_amplified": 234192
+            },
+            {
+              "risk": 1,"country": "GE","date": "2017-01-09",
+              "count": "15898","count_amplified": 241818
+            },
+            {
+              "risk": 1,"country": "GE","date": "2017-01-02",
+              "count": "6324","count_amplified": 259284
+            }
+          ],
+          kz: [
+            {
+              "risk": 1,"country": "KZ","date": "2017-01-16",
+              "count": "29399","count_amplified": 1205359
+            },
+            {
+              "risk": 1,"country": "KZ","date": "2017-01-09",
+              "count": "30580","count_amplified": 1253780
+            },
+            {
+              "risk": 1,"country": "KZ","date": "2017-01-02",
+              "count": "27083","count_amplified": 1110403
+            }
+          ],
+          us: [
+            {
+              "risk": 1,"country": "US","date": "2017-01-16",
+              "count": "82772","count_amplified": 35373652
+            },
+            {
+              "risk": 1,"country": "US","date": "2017-01-09",
+              "count": "56717","count_amplified": 35125397
+            },
+            {
+              "risk": 1,"country": "US","date": "2017-01-02",
+              "count": "66268","count_amplified": 35516988
+            },
+          ],
+          t: [
+            {
+              "risk": 1,"country": "T","date": "2017-01-16",
+              "count": "81548","count_amplified": 156434762
+            },
+            {
+              "risk": 1,"country": "T","date": "2017-01-09",
+              "count": "33172","count_amplified": 157100602
+            },
+            {
+              "risk": 1,"country": "T","date": "2017-01-02",
+              "count": "32558","count_amplified": 156849067
+            }
+          ]
+        }
+      },
+      countries: {
+        '': {title: 'Select a country'},
+        't': {title: 'Global'},
+        'ge': {title: 'Georgia'},
+        'kz': {title: 'Kazakhstan'},
+        'gb': {title: 'United Kingdom'},
+        'us': {title: 'United States'}
+      },
+      graphOptions: {},
+      views: {
+        1: {
+          type: "country/performance",
+          country: "gb",
+          risk: 1,
+          selectorConfig: [
+            {disabled: true, country: "gb"},
+            {disabled: true, country: "t"},
+            {disabled: false, country: undefined},
+            {disabled: false, country: undefined},
+            {disabled: false, country: undefined}
+          ]
+        }
+      }
+    }
+
+    const enzymeWrapper = shallow(< CountryPerformanceOnRisk {...props} />)
+
+    return {
+      props,
+      enzymeWrapper
+    }
+  }
 
   it('computeState works', () => {
-    const wrapper = shallow(< CountryPerformanceOnRisk countries={['Is Working']}/>)
-    let out = wrapper.instance().computeState()
-    expect(out.countries).toEqual(['Is Working'])
+    const { enzymeWrapper } = setup()
+    let out = enzymeWrapper.instance().computeState()
+    expect(out.countries[1].label).toEqual('Global')
+    expect(out.countries[1].value).toEqual('t')
   })
 
-  it('Div with id DDOS-graph is there', () => {
-    const wrapper = shallow(< CountryPerformanceOnRisk />)
-    expect(toJson(wrapper)).toMatchSnapshot();
+  it('Renders expected DOM', () => {
+    const { enzymeWrapper } = setup()
+    expect(toJson(enzymeWrapper)).toMatchSnapshot();
   })
 
-  // it('When a country is selected, it updates state of the container', () => {
-  //   function stub() {return ''}
-  //   const wrapper = shallow(< CountryPerformanceOnRisk dispatch={stub} />)
-  //   let newCountry = {value: 'us', label: 'United States'}
-  //   expect(wrapper.find('CountrySelect').at(2).props().selectedCountry)
-  //     .toEqual(undefined)
-  //   wrapper.find('CountrySelect').at(2).simulate('change', newCountry)
-  //   expect(wrapper.find('CountrySelect').at(2).props().selectedCountry)
-  //     .toEqual(newCountry)
-  // })
+  it('convertToPlotlySeries method works', () => {
+    const { enzymeWrapper, props } = setup()
+    let out = enzymeWrapper.instance().convertToPlotlySeries('t', 1, props.cubeByRiskByCountry)
+    expect(out.type).toEqual('scatter')
+    expect(out.x).toEqual(["2017-01-16", "2017-01-09", "2017-01-02"])
+    expect(out.y).toEqual(["81548", "33172", "32558"])
+    expect(out.name).toEqual('Global')
+  })
+
+  it('When a country is selected, it updates state of the container', () => {
+    const { enzymeWrapper, props } = setup()
+    let newCountry = {value: 'us', label: 'United States'}
+    enzymeWrapper.setState(enzymeWrapper.instance().computeState())
+    expect(enzymeWrapper.find('CountrySelect').at(2).props().selectedCountry)
+      .toEqual(undefined)
+    enzymeWrapper.find('CountrySelect').at(2).simulate('change', newCountry)
+    expect(props.dispatch.mock.calls.length).toEqual(1)
+    expect(props.dispatch.mock.calls[0][0]).toEqual({
+      "idxOfSelector": 2,
+      "selectedCountry": "us",
+      "type": "SELECT"
+    })
+  })
 
 })
 

--- a/tests/CountryPerformanceOnRisk.component.test.js
+++ b/tests/CountryPerformanceOnRisk.component.test.js
@@ -8,9 +8,9 @@ import toJson from 'enzyme-to-json';
 describe('Components are working fine', () => {
 
   it('computeState works', () => {
-    const wrapper = shallow(< CountryPerformanceOnRisk data={['Is Working']}/>)
+    const wrapper = shallow(< CountryPerformanceOnRisk countries={['Is Working']}/>)
     let out = wrapper.instance().computeState()
-    expect(out.data).toEqual(['Is Working'])
+    expect(out.countries).toEqual(['Is Working'])
   })
 
   it('Div with id DDOS-graph is there', () => {
@@ -18,16 +18,16 @@ describe('Components are working fine', () => {
     expect(toJson(wrapper)).toMatchSnapshot();
   })
 
-  it('When a country is selected, it updates state of the container', () => {
-    function stub() {return ''}
-    const wrapper = shallow(< CountryPerformanceOnRisk dispatch={stub} />)
-    let newCountry = {value: 'us', label: 'United States'}
-    expect(wrapper.find('CountrySelect').at(2).props().selectedCountry)
-      .toEqual(undefined)
-    wrapper.find('CountrySelect').at(2).simulate('change', newCountry)
-    expect(wrapper.find('CountrySelect').at(2).props().selectedCountry)
-      .toEqual(newCountry)
-  })
+  // it('When a country is selected, it updates state of the container', () => {
+  //   function stub() {return ''}
+  //   const wrapper = shallow(< CountryPerformanceOnRisk dispatch={stub} />)
+  //   let newCountry = {value: 'us', label: 'United States'}
+  //   expect(wrapper.find('CountrySelect').at(2).props().selectedCountry)
+  //     .toEqual(undefined)
+  //   wrapper.find('CountrySelect').at(2).simulate('change', newCountry)
+  //   expect(wrapper.find('CountrySelect').at(2).props().selectedCountry)
+  //     .toEqual(newCountry)
+  // })
 
 })
 

--- a/tests/CountryPerformanceOnRisk.component.test.js
+++ b/tests/CountryPerformanceOnRisk.component.test.js
@@ -144,7 +144,7 @@ describe('Components are working fine', () => {
     expect(enzymeWrapper.find('CountrySelect').at(2).props().selectedCountry)
       .toEqual(undefined)
     enzymeWrapper.find('CountrySelect').at(2).simulate('change', newCountry)
-    expect(props.dispatch.mock.calls.length).toEqual(1)
+    expect(props.dispatch.mock.calls.length).toEqual(2)
     expect(props.dispatch.mock.calls[0][0]).toEqual({
       "idxOfSelector": 2,
       "selectedCountry": "us",

--- a/tests/__snapshots__/CountryPerformanceOnRisk.component.test.js.snap
+++ b/tests/__snapshots__/CountryPerformanceOnRisk.component.test.js.snap
@@ -6,25 +6,26 @@ exports[`Components are working fine Div with id DDOS-graph is there 1`] = `
     graphOptions={Object {}} />
   <CountrySelect
     disabled={true}
-    onChange={[Function]} />
+    onChange={[Function]}
+    selectOptions={Array []}
+    selectedCountry="gb" />
   <CountrySelect
     disabled={true}
     onChange={[Function]}
-    selectedCountry={
-      Object {
-        "label": "Global",
-        "value": "t",
-      }
-    } />
+    selectOptions={Array []}
+    selectedCountry="t" />
   <CountrySelect
     disabled={false}
-    onChange={[Function]} />
+    onChange={[Function]}
+    selectOptions={Array []} />
   <CountrySelect
     disabled={false}
-    onChange={[Function]} />
+    onChange={[Function]}
+    selectOptions={Array []} />
   <CountrySelect
     disabled={false}
-    onChange={[Function]} />
+    onChange={[Function]}
+    selectOptions={Array []} />
 </div>
 `;
 

--- a/tests/__snapshots__/CountryPerformanceOnRisk.component.test.js.snap
+++ b/tests/__snapshots__/CountryPerformanceOnRisk.component.test.js.snap
@@ -1,31 +1,8 @@
-exports[`Components are working fine Div with id DDOS-graph is there 1`] = `
+exports[`Components are working fine Renders expected DOM 1`] = `
 <div>
   <PlotlyGraph
-    data={Array []}
     graphID="DDOS-graph"
     graphOptions={Object {}} />
-  <CountrySelect
-    disabled={true}
-    onChange={[Function]}
-    selectOptions={Array []}
-    selectedCountry="gb" />
-  <CountrySelect
-    disabled={true}
-    onChange={[Function]}
-    selectOptions={Array []}
-    selectedCountry="t" />
-  <CountrySelect
-    disabled={false}
-    onChange={[Function]}
-    selectOptions={Array []} />
-  <CountrySelect
-    disabled={false}
-    onChange={[Function]}
-    selectOptions={Array []} />
-  <CountrySelect
-    disabled={false}
-    onChange={[Function]}
-    selectOptions={Array []} />
 </div>
 `;
 

--- a/tests/__snapshots__/CountryPerformanceOnRisk.component.test.js.snap
+++ b/tests/__snapshots__/CountryPerformanceOnRisk.component.test.js.snap
@@ -1,6 +1,7 @@
 exports[`Components are working fine Renders expected DOM 1`] = `
 <div>
   <PlotlyGraph
+    data={Array []}
     graphID="DDOS-graph"
     graphOptions={Object {}} />
 </div>

--- a/tests/actions.test.js
+++ b/tests/actions.test.js
@@ -3,7 +3,7 @@ import httpAdapter from 'axios/lib/adapters/http'
 import nock from 'nock'
 import configureMockStore from 'redux-mock-store'
 import thunk from 'redux-thunk'
-import * as actions from '../src/actions/DDOSactions'
+import * as actions from '../src/actions/cubeActions'
 
 const middlewares = [ thunk ]
 const mockStore = configureMockStore(middlewares)
@@ -17,7 +17,7 @@ describe('async actions', () => {
   beforeEach(() =>{
     nock(host)
       .persist()
-      .get('/api/count_by_country?limit=500&country=T&risk=1')
+      .get('/api/count_by_country?limit=500&country=t&risk=1')
       .replyWithFile(200, './public/fixtures/country/global/dns.json')
   });
 
@@ -25,27 +25,27 @@ describe('async actions', () => {
    nock.cleanAll();
   });
 
-  it('Creates FETCH_RISK_REQUEST action when fetching the API begins', () => {
+  it('Creates FETCH_DATA_REQUEST action when fetching the API begins', () => {
     const store = mockStore({})
-    store.dispatch(actions.fetchRisk(1))
+    store.dispatch(actions.fetchData('t', 1))
     let actionCreators = store.getActions()
-    expect(actionCreators[0].type).toEqual('FETCH_RISK_REQUEST')
+    expect(actionCreators[0].type).toEqual('FETCH_DATA_REQUEST')
   })
 
-  it('Creates FETCH_RISK_SUCCESS actions when fetching the API succeed', async () => {
+  it('Creates FETCH_DATA_SUCCESS actions when fetching the API succeed', async () => {
     const store = mockStore({})
-    await store.dispatch(actions.fetchRisk(1))
+    await store.dispatch(actions.fetchData('t', 1))
     let actionCreators = store.getActions()
-    expect(actionCreators[1].type).toEqual('FETCH_RISK_SUCCESS')
+    expect(actionCreators[1].type).toEqual('FETCH_DATA_SUCCESS')
     expect(actionCreators[1].data[0].risk).toEqual(1)
     expect(actionCreators[1].data[0].country).toEqual('T')
   })
 
-  it('Creates FETCH_RISK_FAILURE actions when fetching the API failed', async () => {
+  it('Creates FETCH_DATA_FAILURE actions when fetching the API failed', async () => {
     const store = mockStore({})
-    await store.dispatch(actions.fetchRisk('error'))
+    await store.dispatch(actions.fetchData('error'))
     let actionCreators = store.getActions()
-    expect(actionCreators[1].type).toEqual('FETCH_RISK_FAILURE')
+    expect(actionCreators[1].type).toEqual('FETCH_DATA_FAILURE')
     expect(actionCreators[1].error).toContain('No match for request get')
   })
 

--- a/tests/actions.test.js
+++ b/tests/actions.test.js
@@ -46,7 +46,7 @@ describe('async actions', () => {
     await store.dispatch(actions.fetchData('error'))
     let actionCreators = store.getActions()
     expect(actionCreators[1].type).toEqual('FETCH_DATA_FAILURE')
-    expect(actionCreators[1].error).toContain('No match for request get')
+    expect(actionCreators[1].error).toContain('No match for request')
   })
 
 })

--- a/tests/cubeReducers.test.js
+++ b/tests/cubeReducers.test.js
@@ -42,7 +42,7 @@ describe('buildCube reducer', () => {
   it('On failure - no data is fetched and error message is returned', () => {
     let newStore = buildCube(initialState, {
       type: 'FETCH_DATA_FAILURE',
-      errorMessage: 'test error',
+      error: 'test error',
       country: 'gb',
       risk: 1
     });

--- a/tests/cubeReducers.test.js
+++ b/tests/cubeReducers.test.js
@@ -1,0 +1,58 @@
+import { buildCube } from '../src/reducers/cubeReducers';
+
+describe('buildCube reducer', () => {
+  const initialState = {
+    entities: {
+      countries: {},
+      risks: {},
+      cubeByRiskByCountry: {}
+    },
+    views: { 1: {} }
+  }
+
+  it('While requesting sets isFetching=true, shold not modify cube', () => {
+    let newStore = buildCube(initialState, {
+      type: 'FETCH_DATA_REQUEST',
+      country: 'gb',
+      risk: 1
+    });
+    expect(newStore.views[1].isFetching).toBeTruthy()
+    expect(newStore.views[1].isFetched).toBeFalsy()
+    expect(newStore.views[1].didFailed).toBeFalsy()
+    expect(newStore.entities).toEqual(initialState.entities)
+  })
+
+  it('On success it puts data in cubeByRiskByCountry and sets isFetched=true', () => {
+    let data = [{
+      "risk": 1,"country": "GB","date": "2017-01-16",
+      "count": "11506","count_amplified": 4571746
+    }]
+    let newStore = buildCube(initialState, {
+      type: 'FETCH_DATA_SUCCESS',
+      data: data,
+      country: 'gb',
+      risk: 1
+    });
+    expect(newStore.views[1].isFetching).toBeFalsy()
+    expect(newStore.views[1].isFetched).toBeTruthy()
+    expect(newStore.views[1].didFailed).toBeFalsy()
+    expect(newStore.entities.cubeByRiskByCountry[1]['gb']).toEqual(data)
+  })
+
+  it('On failure - no data is fetched and error message is returned', () => {
+    let newStore = buildCube(initialState, {
+      type: 'FETCH_DATA_FAILURE',
+      errorMessage: 'test error',
+      country: 'gb',
+      risk: 1
+    });
+    let expected = {
+      type: 'country/performance',
+      risk: 1,country: 'gb',
+      isFetched: false,isFetching: false,didFailed: true,
+      errorMessage: 'test error'
+    }
+    expect(newStore.views[1]).toEqual(expected)
+    expect(newStore.entities).toEqual(initialState.entities)
+  })
+})

--- a/tests/cubeReducers.test.js
+++ b/tests/cubeReducers.test.js
@@ -55,4 +55,24 @@ describe('buildCube reducer', () => {
     expect(newStore.views[1]).toEqual(expected)
     expect(newStore.entities).toEqual(initialState.entities)
   })
+
+  it('On selector change it updates selectorConfig in views of store', () => {
+    let newState = Object.assign({}, initialState, {
+      views: {
+        1: {
+          selectorConfig: [
+            {disabled: true, country: "gb"},
+            {disabled: true, country: "t"},
+            {disabled: false, country: undefined}
+          ]
+        }
+      }
+    })
+    let newStore = buildCube(newState, {
+      type: 'SELECT',
+      idxOfSelector: 2,
+      selectedCountry: 'gb'
+    });
+    expect(newStore.views[1].selectorConfig[2].country).toEqual('gb')
+  })
 })


### PR DESCRIPTION
This PR introduces to new (and closes to final) structure of Redux store. Previous `data` that was holding ready data for Plotly charts, are replaced with `cubeByRiskByCountry` key inside "entities", It now holds results of actual API calls. that are all loaded asynchronously with actions and reducers when main component is mounted, or updated.

PR includes 
- new structure of store
- Main component re factor to handle new structure of store 
- Function to transform API result to `Plotly` usable data
  - Test for `convertToPlotlySeries`
- Selector configuration refactored and moved out into views of Redux store
- Action and reducer for selecting country
  - tests for this functions
- Mocked result of API call removed from redux store.
- Data loaded asynchronously on `componentDidMount` and update
- New actions using `Thunk`library  for async fetching data from API
  - Tests for actions
- Reducers for updating New store per action. (Without mutating store)
  - Tests for Reducers

closes #18 

Also fixes Travis build