### PR TITLE
Caching data for graph

### DIFF
--- a/src/actions/cubeActions.js
+++ b/src/actions/cubeActions.js
@@ -51,6 +51,25 @@ export function fetchData(country, risk, test=false) {
   }
 }
 
+export function shouldFetchData(state, country, risk) {
+  const data = state.entities.cubeByRiskByCountry[risk]
+  if (!data || !data[country]) {
+    return true
+  } else {
+    return false
+  }
+}
+
+export function fetchDataIfNeeded(country, risk) {
+  return (dispatch, getState) => {
+    if (shouldFetchData(getState(), country, risk)) {
+      return dispatch(fetchData(country, risk))
+    } else {
+      return Promise.resolve()
+    }
+  }
+}
+
 export const SET_VIEWS = 'SET_VIEWS'
 export function setViews(viewOptions) {
   return {

--- a/src/components/CountryPerformanceOnRisk.js
+++ b/src/components/CountryPerformanceOnRisk.js
@@ -3,7 +3,7 @@ import { connect } from 'react-redux'
 import PlotlyGraph from './Plot.js';
 import Select from 'react-select';
 import 'react-select/dist/react-select.css';
-import { countryIsSelected, fetchData, setViews } from '../actions/cubeActions';
+import { countryIsSelected, fetchData, setViews, fetchDataIfNeeded } from '../actions/cubeActions';
 
 
 export class CountryPerformanceOnRisk extends Component {
@@ -55,11 +55,11 @@ export class CountryPerformanceOnRisk extends Component {
 
   async componentDidMount() {
     await this.props.dispatch(setViews(this.props.serverProps))
-    this.props.dispatch(fetchData(
+    this.props.dispatch(fetchDataIfNeeded(
       this.props.views[1].country,
       this.props.views[1].risk
     ))
-    this.props.dispatch(fetchData(
+    this.props.dispatch(fetchDataIfNeeded(
       't',
       this.props.views[1].risk
     ))
@@ -73,9 +73,13 @@ export class CountryPerformanceOnRisk extends Component {
 
 
   updateValue(idxOfSelector, selectedCountry) {
-    selectedCountry = selectedCountry || { value: "" }
-    this.props.dispatch(countryIsSelected(idxOfSelector, selectedCountry.value))
-    this.props.dispatch(fetchData(selectedCountry.value,this.props.views[1].risk))
+    if(!selectedCountry || selectedCountry.value === "") {
+      this.props.dispatch(countryIsSelected(idxOfSelector, ""))
+    } else {
+      this.props.dispatch(countryIsSelected(idxOfSelector, selectedCountry.value))
+      this.props.dispatch(fetchDataIfNeeded(selectedCountry.value,this.props.views[1].risk))
+    }
+
   }
 
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
 /* global graphData */
 import React from 'react';
 import ReactDOM from 'react-dom';
-import { createStore, applyMiddleware } from 'redux';
+import { createStore, applyMiddleware, compose } from 'redux';
 import thunk from 'redux-thunk';
 import { Provider } from 'react-redux';
 import { buildCube } from './reducers/cubeReducers';
@@ -43,11 +43,11 @@ let reduxStore = {
   views: {}
 }
 
-
+const composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose;
 let store = createStore(
   buildCube,
   reduxStore,
-  applyMiddleware(thunk)
+  composeEnhancers(applyMiddleware(thunk))
 )
 
 const serverProps = {country: 'gb', risk: [1], type: 'country/performance'}

--- a/src/reducers/cubeReducers.js
+++ b/src/reducers/cubeReducers.js
@@ -19,8 +19,6 @@ export function buildCube(state=initialState, action) {
       return update(state, {
         views: {
           1 :{
-            type: {$set: 'country/performance'},
-            risk: {$set: action.risk}, country: {$set: action.country},
             isFetched: {$set: false},
             isFetching: {$set: false},
             didFailed: {$set: true},
@@ -32,8 +30,6 @@ export function buildCube(state=initialState, action) {
       return update(state, {
         views: {
           1 :{
-            type: {$set: 'country/performance'},
-            risk: {$set: action.risk}, country: {$set: action.country},
             isFetched: {$set: false},
             isFetching: {$set: true},
             didFailed: {$set: false}
@@ -44,8 +40,6 @@ export function buildCube(state=initialState, action) {
       let newState = update(state, {
         views: {
           1 :{
-            type: {$set: 'country/performance'},
-            risk: {$set: action.risk}, country: {$set: action.country},
             isFetched: {$set: true},
             isFetching: {$set: false},
             didFailed: {$set: false}

--- a/tests/actions.test.js
+++ b/tests/actions.test.js
@@ -50,3 +50,39 @@ describe('async actions', () => {
   })
 
 })
+
+describe('how cached data is used', () => {
+  it('checks if given country and risk data is cached', () => {
+    const testState = {
+      entities: {
+        cubeByRiskByCountry: {
+          1: {
+            'gb': 'data'
+          }
+        }
+      }
+    }
+    const dataIsCached = actions.shouldFetchData(testState, 'gb', 1)
+    const dataIsNotCached = actions.shouldFetchData(testState, 'us', 1)
+    //if data cached it returns false so we don't make a server request
+    expect(dataIsCached).toBeFalsy()
+    expect(dataIsNotCached).toBeTruthy()
+  })
+
+  it('Checks if no fetching started if data is in cubeByRiskByCountry and fetching started if oposite', () => {
+    const store = mockStore({
+      entities: {
+        cubeByRiskByCountry:{ 1: {'test': []}}
+      }
+    })
+    // if data is there no actions called
+    store.dispatch(actions.fetchDataIfNeeded('test', 1))
+    let actionCreators = store.getActions()
+    expect(actionCreators.length).toEqual(0)
+    // if fata is not there FETCH_DATA_REQUEST is triggered
+    store.dispatch(actions.fetchDataIfNeeded('newTest', 1))
+    actionCreators = store.getActions()
+    expect(actionCreators.length).toEqual(1)
+    expect(actionCreators[0].type).toEqual('FETCH_DATA_REQUEST')
+  })
+})

--- a/tests/cubeReducers.test.js
+++ b/tests/cubeReducers.test.js
@@ -1,15 +1,21 @@
 import { buildCube } from '../src/reducers/cubeReducers';
 
 describe('buildCube reducer', () => {
-  const initialState = {
+  const preInitialState = {
     entities: {
       countries: {},
       risks: {},
       cubeByRiskByCountry: {}
     },
-    // Fetching data assumes that there is at least one view inside store
-    views: { 1: {} }
+    views: {}
   }
+  // We are setting initial views here to check later on
+  const initialState = buildCube(preInitialState, {
+    type: 'SET_VIEWS',
+    viewOptions: {country: 'gb', risk: [1], type: 'testing'},
+    risk: 1
+  });
+
   const stateClone = Object.assign({}, initialState)
 
   it('While requesting sets isFetching=true, shold not modify cube', () => {
@@ -48,13 +54,10 @@ describe('buildCube reducer', () => {
       country: 'gb',
       risk: 1
     });
-    let expected = {
-      type: 'country/performance',
-      risk: 1,country: 'gb',
-      isFetched: false,isFetching: false,didFailed: true,
-      errorMessage: 'test error'
-    }
-    expect(newStore.views[1]).toEqual(expected)
+    expect(newStore.views[1].isFetching).toBeFalsy()
+    expect(newStore.views[1].isFetched).toBeFalsy()
+    expect(newStore.views[1].didFailed).toBeTruthy()
+    expect(newStore.views[1].errorMessage).toEqual('test error')
     expect(newStore.entities).toEqual(initialState.entities)
   })
 


### PR DESCRIPTION
* enabled `redux devtools` extension for Chrome browser
* refactored tests for reducers and reducers itself
* added new tests for checking if data was already cached
* added new actions that check if data is already cached - if so it does not make server request
* refactored CountryPerformanceOnRisk component to use new actions
* refactored CountryPerformanceOnRisk component to not dispatch fetching data action when selected country is undefined or empty string