### PR TITLE
Normalized counts

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -44,6 +44,7 @@
           isFetched: false,
           isFetching: false,
           didFailed: false,
+          measure: "count_normalized",
           selectorConfig: [
             {disabled: true, country: 'gb'},
             {disabled: true, country: 't'},

--- a/src/components/CountryPerformanceOnRisk.js
+++ b/src/components/CountryPerformanceOnRisk.js
@@ -25,7 +25,12 @@ export class CountryPerformanceOnRisk extends Component {
     if (props.view.isFetched) {
         plotlyData = props.view.selectorConfig.map(config => {
         if (config.country){
-          return this.convertToPlotlySeries(config.country, 1, props.cubeByRiskByCountry)
+          return this.convertToPlotlySeries(
+            config.country,
+            props.view.risk,
+            props.cubeByRiskByCountry,
+            props.view.measure
+          )
         }
       }).filter(value => {return value !== undefined})
     }
@@ -39,11 +44,11 @@ export class CountryPerformanceOnRisk extends Component {
   }
 
 
-  convertToPlotlySeries(countryID, riskID, cubeByRiskByCountry) {
+  convertToPlotlySeries(countryID, riskID, cubeByRiskByCountry, measure) {
     var dataTable = cubeByRiskByCountry[riskID][countryID];
     return {
       x: dataTable.map(row => row.date),
-      y: dataTable.map(row => row.count),
+      y: dataTable.map(row => row[measure] || row.count),
       name: this.props.countries[countryID].name,
       type: 'scatter',
     }

--- a/tests/CountryPerformanceOnRisk.component.test.js
+++ b/tests/CountryPerformanceOnRisk.component.test.js
@@ -14,71 +14,71 @@ describe('Components are working fine', () => {
           gb: [
             {
               "risk": 1,"country": "GB","date": "2017-01-16",
-              "count": "11506","count_amplified": 4571746
+              "count": "11506","count_amplified": 4571746, "count_normalized": 123
             },
             {
               "risk": 1,"country": "GB","date": "2017-01-09",
-              "count": "13330","count_amplified": 4646530
+              "count": "13330","count_amplified": 4646530, "count_normalized": 105
             },
             {
               "risk": 1,"country": "GB","date": "2017-01-02",
-              "count": "11471","count_amplified": 4570311
+              "count": "11471","count_amplified": 4570311, "count_normalized": 100
             }
           ],
           ge: [
             {
               "risk": 1,"country": "GE","date": "2017-01-16",
-              "count": "25712","count_amplified": 234192
+              "count": "25712","count_amplified": 234192, "count_normalized": 111
             },
             {
               "risk": 1,"country": "GE","date": "2017-01-09",
-              "count": "15898","count_amplified": 241818
+              "count": "15898","count_amplified": 241818, "count_normalized": 189
             },
             {
               "risk": 1,"country": "GE","date": "2017-01-02",
-              "count": "6324","count_amplified": 259284
+              "count": "6324","count_amplified": 259284, "count_normalized": 103
             }
           ],
           kz: [
             {
               "risk": 1,"country": "KZ","date": "2017-01-16",
-              "count": "29399","count_amplified": 1205359
+              "count": "29399","count_amplified": 1205359, "count_normalized": 220
             },
             {
               "risk": 1,"country": "KZ","date": "2017-01-09",
-              "count": "30580","count_amplified": 1253780
+              "count": "30580","count_amplified": 1253780, "count_normalized": 90
             },
             {
               "risk": 1,"country": "KZ","date": "2017-01-02",
-              "count": "27083","count_amplified": 1110403
+              "count": "27083","count_amplified": 1110403, "count_normalized": 56
             }
           ],
           us: [
             {
               "risk": 1,"country": "US","date": "2017-01-16",
-              "count": "82772","count_amplified": 35373652
+              "count": "82772","count_amplified": 35373652, "count_normalized": 200
             },
             {
               "risk": 1,"country": "US","date": "2017-01-09",
-              "count": "56717","count_amplified": 35125397
+              "count": "56717","count_amplified": 35125397, "count_normalized": 10
             },
             {
               "risk": 1,"country": "US","date": "2017-01-02",
-              "count": "66268","count_amplified": 35516988
+              "count": "66268","count_amplified": 35516988, "count_normalized": 190
             },
           ],
           t: [
             {
               "risk": 1,"country": "T","date": "2017-01-16",
-              "count": "81548","count_amplified": 156434762
+              "count": "81548","count_amplified": 156434762, "count_normalized": 120
             },
             {
               "risk": 1,"country": "T","date": "2017-01-09",
-              "count": "33172","count_amplified": 157100602
+              "count": "33172","count_amplified": 157100602, "count_normalized": 30
             },
             {
               "risk": 1,"country": "T","date": "2017-01-02",
-              "count": "32558","count_amplified": 156849067
+              "count": "32558","count_amplified": 156849067, "count_normalized": 330
             }
           ]
         }
@@ -97,6 +97,7 @@ describe('Components are working fine', () => {
         type: "country/performance",
         country: "gb",
         risk: 1,
+        measure: "count_normalized",
         selectorConfig: [
           {disabled: true, country: "gb"},
           {disabled: true, country: "t"},
@@ -128,11 +129,15 @@ describe('Components are working fine', () => {
 
   it('convertToPlotlySeries method works', () => {
     const { enzymeWrapper, props } = setup()
-    let out = enzymeWrapper.instance().convertToPlotlySeries('t', 1, props.cubeByRiskByCountry)
+    let out = enzymeWrapper.instance().convertToPlotlySeries('t', 1, props.cubeByRiskByCountry, 'count')
     expect(out.type).toEqual('scatter')
     expect(out.x).toEqual(["2017-01-16", "2017-01-09", "2017-01-02"])
     expect(out.y).toEqual(["81548", "33172", "32558"])
     expect(out.name).toEqual('Global')
+    out = enzymeWrapper.instance().convertToPlotlySeries('t', 1, props.cubeByRiskByCountry, 'count_normalized')
+    expect(out.y).toEqual([120, 30, 330])
+    out = enzymeWrapper.instance().convertToPlotlySeries('t', 1, props.cubeByRiskByCountry, 'count_amplified')
+    expect(out.y).toEqual([156434762, 157100602, 156849067])
   })
 
   it('When a country is selected, it updates state of the container', () => {


### PR DESCRIPTION
PR to have configurable measures for graphs
Note that most of the job is done on server side, meaning received response from API includes key `normolized_count`. This Change just allows to dynamically choose what measure to use according to views.

- includes tests 
- mock up
- function refactored to get the measure that is passed as an argument

@anuveyatsu please review and merge if you have some time tomorrow