### PR TITLE
Source of infection using new API

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -216,8 +216,8 @@
       }
     </script>
 
-    <!-- <div id="countryPerformance" class="container"></div> -->
-    <div id="ASPerformance" class="container"></div>
+    <div id="countryPerformance" class="container"></div>
+    <!-- <div id="ASPerformance" class="container"></div> -->
     <!-- <div id="dropdown"></div>
     <div id="ddos"></div> -->
   </body>

--- a/src/actions/cubeActions.js
+++ b/src/actions/cubeActions.js
@@ -46,7 +46,7 @@ export function countryIsSelected(idxOfSelector, selectedCountry, graphId) {
 export function fetchData(country, risk, graphId, test=false) {
   return function(dispatch) {
     dispatch(requestData(country, risk, graphId))
-    let ENDPOINT = `/api/v1/count_by_country?limit=500&country=${country}&risk=${risk}`
+    let ENDPOINT = `/api/v1/count_by_country?limit=500&country=${country}&risk=${risk}&drilldown=as`
     if(!test) {
       ENDPOINT = CG_API_ENDPOINT + ENDPOINT
     }

--- a/src/components/CountryPage.js
+++ b/src/components/CountryPage.js
@@ -83,6 +83,9 @@ export class CountryPage extends Component {
               <div className="col-md-6 panel panel-default">
                 <CountryPerformanceOnRisk view={this.props.views[key]} viewId={key}/>
               </div>
+              <div className="col-md-6 panel panel-default">
+                <SourceOfInfection view={this.props.views[key]} viewId={key+idx}/>
+              </div>
             </div>
           )
         })}

--- a/src/components/CountryPage.js
+++ b/src/components/CountryPage.js
@@ -77,14 +77,14 @@ export class CountryPage extends Component {
             </div>
           </div>
         </div>
-        {Object.keys(this.props.views).map((key, idx) => {
+        {Object.values(this.props.views).map(view => {
           return (
-            <div key={key} className="row">
+            <div key={view.id} className="row">
               <div className="col-md-6 panel panel-default">
-                <CountryPerformanceOnRisk view={this.props.views[key]} viewId={key}/>
+                <CountryPerformanceOnRisk view={view} viewId={view.id}/>
               </div>
               <div className="col-md-6 panel panel-default">
-                <SourceOfInfection view={this.props.views[key]} viewId={key+idx}/>
+                <SourceOfInfection view={view} viewId={'SOI/'+view.id}/>
               </div>
             </div>
           )

--- a/src/components/Plot.js
+++ b/src/components/Plot.js
@@ -16,7 +16,7 @@ class PlotlyGraph extends React.Component {
     this.drawPlot(this.props.data, this.props.graphOptions);
     if(this.props.clickable) {
       document.getElementById(this.props.graphID).on('plotly_click', function(data){
-        if(data.points[0].data.name !== 0) {
+        if(data.points[0].data.name !== 'Rest') {
           window.location = `/asn/${data.points[0].data.name}`
         }
       });

--- a/src/components/SourceOfInfection.js
+++ b/src/components/SourceOfInfection.js
@@ -11,14 +11,14 @@ export class SourceOfInfection extends Component {
         barmode: 'stack',
         hovermode:'closest',
         showlegend: false,
-        height: 234,
+        height: 240,
         margin: {
           l: 30,r: 30,
           b: 30,t: 0
         },
         xaxis: {
           gridcolor: 'transparent',
-          tickformat: '%Y'
+          tickformat: '%Y-%m-%d'
         },
         font: {
           size: 9,

--- a/src/components/SourceOfInfection.js
+++ b/src/components/SourceOfInfection.js
@@ -35,9 +35,9 @@ export class SourceOfInfection extends Component {
 
     props.data[props.view.risk][props.view.country].forEach(dataEntry => {
       let colorPallet = [
-        'rgb(167,133,243)', 'rgb(199,179,249)', 'rgb(173,246,250)',
-        'rgb(124,244,251)', 'rgb(41,232,251)', 'rgb(212,229,250)',
-        'rgb(169,205,250)', 'rgb(140,181,253)', 'rgb(20,105,234)'
+        'rgb(78, 31, 190)', 'rgb(122,71,239)', 'rgb(167,133,243)',
+        'rgb(199,179,249)', 'rgb(100,200,250)', 'rgb(124,244,251)',
+        'rgb(41,232,251)', 'rgb(140,181,253)', 'rgb(20,105,234)'
       ]
       let countAllRest = parseInt(dataEntry.count)
       dataEntry.as.forEach((asn, idx) => {
@@ -53,11 +53,12 @@ export class SourceOfInfection extends Component {
         y: [countAllRest],
         type: 'bar',
         name: 'Rest',
-        marker: {color: 'rgb(122,71,239)'}
+        marker: {color: 'rgb(61, 24, 148)'},
+        text: ['Rest'],
+        hoverinfo: 'x+y+text'
       }
       plotlyData.unshift(traceAllRest)
     })
-
 
     return {plotlyData: plotlyData}
   }
@@ -68,7 +69,9 @@ export class SourceOfInfection extends Component {
       x: [data.date],
       y: [asn.count],
       type: 'bar',
-      name: asn.id
+      name: asn.id,
+      text: [asn.id],
+      hoverinfo: 'x+y+text'
     }
   }
 

--- a/src/components/SourceOfInfection.js
+++ b/src/components/SourceOfInfection.js
@@ -32,26 +32,36 @@ export class SourceOfInfection extends Component {
 
   computeState(props=this.props) {
     let plotlyData = []
+
     props.data[props.view.risk][props.view.country].forEach(dataEntry => {
       let colorPallet = [
-        'rgb(122,71,239)',
         'rgb(167,133,243)', 'rgb(199,179,249)', 'rgb(173,246,250)',
         'rgb(124,244,251)', 'rgb(41,232,251)', 'rgb(212,229,250)',
         'rgb(169,205,250)', 'rgb(140,181,253)', 'rgb(20,105,234)'
       ]
+      let countAllRest = parseInt(dataEntry.count)
       dataEntry.as.forEach((asn, idx) => {
+        countAllRest -= parseInt(asn.count)
         let trace = this.plotlySeries(dataEntry, asn)
         trace['marker'] = {
           color: colorPallet[idx]
         }
         plotlyData.push(trace)
       })
-
+      let traceAllRest = {
+        x: [dataEntry.date],
+        y: [countAllRest],
+        type: 'bar',
+        name: 'Rest',
+        marker: {color: 'rgb(122,71,239)'}
+      }
+      plotlyData.unshift(traceAllRest)
     })
+
 
     return {plotlyData: plotlyData}
   }
-  
+
 
   plotlySeries(data, asn){
     return {
@@ -64,15 +74,18 @@ export class SourceOfInfection extends Component {
 
 
   componentDidMount() {
-    // this.props.view.as.id.forEach(AsId => {
-    //   this.props.dispatch(fetchAsData(this.props.view.country, this.props.view.risk, AsId))
-    // })
-    this.setState(this.computeState(this.props))
+    if(this.props.data[this.props.view.risk] && this.props.data[this.props.view.risk][this.props.view.country]) {
+      this.setState(this.computeState(this.props))
+    }
   };
 
 
   componentWillReceiveProps(nextProps) {
-    this.setState(this.computeState(nextProps))
+    if(this.props.data[this.props.view.risk]) {
+      if(this.props.data[this.props.view.risk][this.props.view.country] != nextProps.data[this.props.view.risk][this.props.view.country]) {
+        this.setState(this.computeState(nextProps))
+      }
+    }
   }
 
 
@@ -95,8 +108,7 @@ export class SourceOfInfection extends Component {
 
 const mapStateToProps = (state) => {
   return {
-    //when API is done we'll need to replace 'cubeByRiskByAS' with 'cubeByRiskByCountry'
-    data: state.entities.cubeByRiskByAS,
+    data: state.entities.cubeByRiskByCountry,
     risks: state.entities.risks
   }
 }

--- a/src/css/temp.css
+++ b/src/css/temp.css
@@ -28,3 +28,8 @@
 .graph-div {
   margin-bottom: 40px;
 }
+
+#countryPerformance .panel {
+  width: 49%;
+  margin: 0.5%;
+}

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-/* global graphData countries countryPerformanceOnRiskViews asn tempData risks ASPerformanceViews*/
+/* global graphData countries countryPerformanceOnRiskViews asn risks ASPerformanceViews*/
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { createStore, applyMiddleware, compose } from 'redux';
@@ -20,7 +20,6 @@ let reduxStore = {
     asn: asn,
     cubeByRiskByCountry: {},
     cubeByRiskByASN: {},
-    //cubeByRiskByAS: tempData,
     layouts: {
       legend: {x:0, y:1},
       height: 200,

--- a/tests/SourceOfInfection.test.js
+++ b/tests/SourceOfInfection.test.js
@@ -10,13 +10,7 @@ describe('Component is working', () => {
       view: {
         id: 'GB/1',
         country: 'GB',
-        risk: 1,
-        AS: {
-          id: [192, 254],
-          isFetched: false,
-          isFetching: false,
-          didFailed: false
-        }
+        risk: 1
       },
       data: {
         1: {
@@ -94,9 +88,8 @@ describe('Component is working', () => {
   it('computeState works', () => {
     const { enzymeWrapper, props } = setup()
     let out = enzymeWrapper.instance().computeState(props)
-    expect(out.plotlyData.length).toEqual(6)
-    expect(out.plotlyData[0].name).toEqual(props.view.AS.id[0])
-    expect(out.plotlyData[1].name).toEqual(props.view.AS.id[1])
+    expect(out.plotlyData.length).toEqual(8)
+    expect(out.plotlyData[0].name).toEqual('Rest')
   })
 
 })

--- a/tests/__snapshots__/CountryPage.test.js.snap
+++ b/tests/__snapshots__/CountryPage.test.js.snap
@@ -91,6 +91,12 @@ exports[`CountryPage components tests if rendered output is expected 1`] = `
         view={Object {}}
         viewId="gb/1" />
     </div>
+    <div
+      className="col-md-6 panel panel-default">
+      <Connect(SourceOfInfection)
+        view={Object {}}
+        viewId="gb/10" />
+    </div>
   </div>
   <div
     className="row">
@@ -99,6 +105,12 @@ exports[`CountryPage components tests if rendered output is expected 1`] = `
       <Connect(CountryPerformanceOnRisk)
         view={Object {}}
         viewId="us/1" />
+    </div>
+    <div
+      className="col-md-6 panel panel-default">
+      <Connect(SourceOfInfection)
+        view={Object {}}
+        viewId="us/11" />
     </div>
   </div>
 </div>

--- a/tests/__snapshots__/CountryPage.test.js.snap
+++ b/tests/__snapshots__/CountryPage.test.js.snap
@@ -88,14 +88,13 @@ exports[`CountryPage components tests if rendered output is expected 1`] = `
     <div
       className="col-md-6 panel panel-default">
       <Connect(CountryPerformanceOnRisk)
-        view={Object {}}
-        viewId="gb/1" />
+        view={Object {}} />
     </div>
     <div
       className="col-md-6 panel panel-default">
       <Connect(SourceOfInfection)
         view={Object {}}
-        viewId="gb/10" />
+        viewId="SOI/undefined" />
     </div>
   </div>
   <div
@@ -103,14 +102,13 @@ exports[`CountryPage components tests if rendered output is expected 1`] = `
     <div
       className="col-md-6 panel panel-default">
       <Connect(CountryPerformanceOnRisk)
-        view={Object {}}
-        viewId="us/1" />
+        view={Object {}} />
     </div>
     <div
       className="col-md-6 panel panel-default">
       <Connect(SourceOfInfection)
         view={Object {}}
-        viewId="us/11" />
+        viewId="SOI/undefined" />
     </div>
   </div>
 </div>

--- a/tests/__snapshots__/SourceOfInfection.test.js.snap
+++ b/tests/__snapshots__/SourceOfInfection.test.js.snap
@@ -14,7 +14,7 @@ exports[`Component is working Renders expected DOM 1`] = `
           "color": "#7f7f7f",
           "size": 9,
         },
-        "height": 234,
+        "height": 240,
         "hovermode": "closest",
         "margin": Object {
           "b": 30,
@@ -25,7 +25,7 @@ exports[`Component is working Renders expected DOM 1`] = `
         "showlegend": false,
         "xaxis": Object {
           "gridcolor": "transparent",
-          "tickformat": "%Y",
+          "tickformat": "%Y-%m-%d",
         },
       }
     } />

--- a/tests/actions.test.js
+++ b/tests/actions.test.js
@@ -18,7 +18,7 @@ describe('async actions', () => {
   beforeEach(() =>{
     nock(host)
       .persist()
-      .get('/api/v1/count_by_country?limit=500&country=t&risk=1')
+      .get('/api/v1/count_by_country?limit=500&country=t&risk=1&drilldown=as')
       .replyWithFile(200, './public/fixtures/country/global/dns.json')
   });
 


### PR DESCRIPTION
* added stacked bar chart for top 9 AS within a country in CountryPage
* changed API path to include top 9 AS data
* added calculation of All The Rest AS count for plotly, refactored to use cubeByRiskByCountry entity in SourceOfInfection
* some refactoring in CountryPage

This PR does not include a spinner implementation - some further research and discussion is needed for it.