### PR TITLE
Safari (and other/older browsers) support

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   },
   "dependencies": {
     "axios": "^0.15.3",
+    "babel-polyfill": "^6.23.0",
     "gl": "^4.0.3",
     "halogen": "^0.2.0",
     "numeral": "^2.0.4",

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
 /* global graphData countries countryPerformanceOnRiskViews asn risks ASPerformanceViews DdosPerformanceViews ChoroplethMapViews*/
+import "babel-polyfill";
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { createStore, applyMiddleware, compose } from 'redux';


### PR DESCRIPTION
Added `babel-polyfill` to support browsers that do not work with ECMAScript 2017 (especially Safari).